### PR TITLE
feat(index): add document registry

### DIFF
--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -1,0 +1,176 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DocId(u32);
+
+impl DocId {
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentMetadata {
+    pub id: DocId,
+    pub path: PathBuf,
+    pub token_length: usize,
+    pub file_size_bytes: u64,
+}
+
+impl DocumentMetadata {
+    fn new(id: DocId, path: PathBuf, token_length: usize, file_size_bytes: u64) -> Self {
+        Self {
+            id,
+            path,
+            token_length,
+            file_size_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DocumentRegistry {
+    documents: HashMap<DocId, DocumentMetadata>,
+    path_to_id: HashMap<PathBuf, DocId>,
+    next_id: u32,
+    total_token_length: u64,
+}
+
+pub trait DocumentCatalog {
+    fn insert_or_update(
+        &mut self,
+        path: PathBuf,
+        token_length: usize,
+        file_size_bytes: u64,
+    ) -> DocId;
+    fn remove(&mut self, path: &Path) -> Option<DocumentMetadata>;
+    fn get(&self, id: DocId) -> Option<&DocumentMetadata>;
+    fn get_by_path(&self, path: &Path) -> Option<&DocumentMetadata>;
+    fn doc_id(&self, path: &Path) -> Option<DocId>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+    fn avg_doc_length(&self) -> f64;
+}
+
+impl DocumentRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl DocumentCatalog for DocumentRegistry {
+    fn insert_or_update(
+        &mut self,
+        path: PathBuf,
+        token_length: usize,
+        file_size_bytes: u64,
+    ) -> DocId {
+        if let Some(&id) = self.path_to_id.get(&path) {
+            if let Some(existing) = self.documents.get_mut(&id) {
+                self.total_token_length -= existing.token_length as u64;
+                self.total_token_length += token_length as u64;
+                *existing = DocumentMetadata::new(id, path, token_length, file_size_bytes);
+            }
+            return id;
+        }
+
+        let id = DocId(self.next_id);
+        self.next_id += 1;
+        let metadata = DocumentMetadata::new(id, path, token_length, file_size_bytes);
+        self.path_to_id.insert(metadata.path.clone(), id);
+        self.total_token_length += token_length as u64;
+        self.documents.insert(id, metadata);
+        id
+    }
+
+    fn remove(&mut self, path: &Path) -> Option<DocumentMetadata> {
+        let id = self.path_to_id.remove(path)?;
+        let metadata = self.documents.remove(&id)?;
+        self.total_token_length -= metadata.token_length as u64;
+        Some(metadata)
+    }
+
+    fn get(&self, id: DocId) -> Option<&DocumentMetadata> {
+        self.documents.get(&id)
+    }
+
+    fn get_by_path(&self, path: &Path) -> Option<&DocumentMetadata> {
+        self.path_to_id
+            .get(path)
+            .and_then(|&id| self.documents.get(&id))
+    }
+
+    fn doc_id(&self, path: &Path) -> Option<DocId> {
+        self.path_to_id.get(path).copied()
+    }
+
+    fn len(&self) -> usize {
+        self.documents.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.documents.is_empty()
+    }
+
+    fn avg_doc_length(&self) -> f64 {
+        if self.documents.is_empty() {
+            return 0.0;
+        }
+
+        self.total_token_length as f64 / self.documents.len() as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{DocumentCatalog, DocumentRegistry};
+
+    #[test]
+    fn insert_assigns_compact_document_ids() {
+        let mut registry = DocumentRegistry::new();
+
+        let first = registry.insert_or_update(PathBuf::from("a.rs"), 3, 10);
+        let second = registry.insert_or_update(PathBuf::from("b.rs"), 5, 20);
+
+        assert_eq!(first.as_u32(), 0);
+        assert_eq!(second.as_u32(), 1);
+    }
+
+    #[test]
+    fn update_preserves_document_id_and_replaces_metadata() {
+        let mut registry = DocumentRegistry::new();
+        let path = PathBuf::from("a.rs");
+        let first = registry.insert_or_update(path.clone(), 3, 10);
+
+        let second = registry.insert_or_update(path.clone(), 7, 30);
+
+        let metadata = registry.get_by_path(&path).unwrap();
+        assert_eq!(second, first);
+        assert_eq!(metadata.token_length, 7);
+        assert_eq!(metadata.file_size_bytes, 30);
+        assert_eq!(registry.avg_doc_length(), 7.0);
+    }
+
+    #[test]
+    fn remove_deletes_metadata_and_updates_stats() {
+        let mut registry = DocumentRegistry::new();
+        registry.insert_or_update(PathBuf::from("a.rs"), 3, 10);
+        registry.insert_or_update(PathBuf::from("b.rs"), 5, 20);
+
+        let removed = registry.remove(PathBuf::from("a.rs").as_path()).unwrap();
+
+        assert_eq!(removed.path, PathBuf::from("a.rs"));
+        assert!(
+            registry
+                .get_by_path(PathBuf::from("a.rs").as_path())
+                .is_none()
+        );
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.avg_doc_length(), 5.0);
+    }
+}

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -7,7 +7,10 @@ use std::{
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use walkdir::WalkDir;
 
-use crate::index::term::Term;
+use crate::index::{
+    document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry},
+    term::Term,
+};
 
 #[derive(Debug)]
 pub struct TermDocument {
@@ -16,25 +19,39 @@ pub struct TermDocument {
 }
 
 #[derive(Debug)]
-pub struct InvertedIndex {
+pub struct InvertedIndex<R = DocumentRegistry> {
     postings: HashMap<Term, HashMap<PathBuf, TermDocument>>,
-    doc_count: usize,
-    total_doc_length: u64,
+    documents: R,
 }
 
-impl InvertedIndex {
+#[derive(Debug)]
+struct ProcessedDocument {
+    path: PathBuf,
+    term_frequencies: HashMap<Term, u32>,
+    token_length: usize,
+    file_size_bytes: u64,
+}
+
+impl InvertedIndex<DocumentRegistry> {
+    #[cfg(test)]
     pub(crate) fn from_postings(postings: HashMap<Term, HashMap<PathBuf, TermDocument>>) -> Self {
-        let mut unique_docs: HashMap<&PathBuf, usize> = HashMap::new();
+        let mut unique_docs: HashMap<PathBuf, usize> = HashMap::new();
         for doc_map in postings.values() {
             for (path, td) in doc_map {
-                unique_docs.entry(path).or_insert(td.length);
+                unique_docs.entry(path.clone()).or_insert(td.length);
             }
         }
 
+        let mut documents = DocumentRegistry::new();
+        let mut unique_docs: Vec<(PathBuf, usize)> = unique_docs.into_iter().collect();
+        unique_docs.sort_by(|(left, _), (right, _)| left.cmp(right));
+        for (path, length) in unique_docs {
+            documents.insert_or_update(path, length, 0);
+        }
+
         InvertedIndex {
-            doc_count: unique_docs.len(),
-            total_doc_length: unique_docs.values().map(|&l| l as u64).sum(),
             postings,
+            documents,
         }
     }
 
@@ -46,12 +63,12 @@ impl InvertedIndex {
         let root_path: PathBuf = root.as_ref().to_owned();
         let drop_prefix = drop_prefix.map(|p| p.as_ref().to_owned());
 
-        let postings = WalkDir::new(root_path)
+        let mut documents: Vec<ProcessedDocument> = WalkDir::new(root_path)
             .into_iter()
             .par_bridge()
             .filter_map(Result::ok)
             .filter(|e| e.file_type().is_file())
-            .map(|entry| {
+            .filter_map(|entry| {
                 let full_path = entry.path().to_path_buf();
 
                 let index_path = if let Some(ref prefix) = drop_prefix {
@@ -63,26 +80,36 @@ impl InvertedIndex {
                     full_path.clone()
                 };
 
-                if let Ok(content) = Self::read_document(&full_path) {
-                    Self::process_document(&index_path, &content, &transform_fn)
-                } else {
-                    HashMap::new()
-                }
+                Self::read_document(&full_path)
+                    .ok()
+                    .map(|content| Self::analyze_document(&index_path, &content, &transform_fn))
             })
-            .reduce(HashMap::new, |mut accumulator, local_map| {
-                for (term, doc_map) in local_map {
-                    accumulator.entry(term).or_default().extend(doc_map);
-                }
-                accumulator
-            });
+            .collect();
 
-        Self::from_postings(postings)
+        documents.sort_by(|left, right| left.path.cmp(&right.path));
+
+        let mut registry = DocumentRegistry::new();
+        let mut postings = HashMap::new();
+        for document in documents {
+            Self::insert_processed_document(&mut registry, &mut postings, document);
+        }
+
+        Self {
+            postings,
+            documents: registry,
+        }
     }
+}
 
+impl<R> InvertedIndex<R>
+where
+    R: DocumentCatalog,
+{
     fn read_document(entry_path: &PathBuf) -> Result<String, std::io::Error> {
         fs::read_to_string(entry_path)
     }
 
+    #[cfg(test)]
     fn process_document<F>(
         entry_path: &Path,
         content: &str,
@@ -91,26 +118,58 @@ impl InvertedIndex {
     where
         F: Fn(&str) -> HashMap<Term, u32> + Sync,
     {
-        let term_frequencies = transform_fn(content);
-        let document_length: usize = term_frequencies.values().map(|&c| c as usize).sum();
+        let document = Self::analyze_document(entry_path, content, transform_fn);
+        Self::postings_for_document(&document)
+    }
 
+    fn analyze_document<F>(entry_path: &Path, content: &str, transform_fn: &F) -> ProcessedDocument
+    where
+        F: Fn(&str) -> HashMap<Term, u32> + Sync,
+    {
+        let term_frequencies = transform_fn(content);
+        let token_length: usize = term_frequencies.values().map(|&c| c as usize).sum();
+
+        ProcessedDocument {
+            path: entry_path.to_path_buf(),
+            term_frequencies,
+            token_length,
+            file_size_bytes: content.len() as u64,
+        }
+    }
+
+    fn postings_for_document(
+        document: &ProcessedDocument,
+    ) -> HashMap<Term, HashMap<PathBuf, TermDocument>> {
         let mut local_map: HashMap<Term, HashMap<PathBuf, TermDocument>> = HashMap::new();
 
-        for (term, freq) in term_frequencies {
-            local_map.entry(term).or_default().insert(
-                entry_path.to_path_buf(),
+        for (term, freq) in &document.term_frequencies {
+            local_map.entry(term.clone()).or_default().insert(
+                document.path.clone(),
                 TermDocument {
-                    length: document_length,
-                    term_freq: freq as usize,
+                    length: document.token_length,
+                    term_freq: *freq as usize,
                 },
             );
         }
 
         local_map
     }
-}
 
-impl InvertedIndex {
+    fn insert_processed_document(
+        registry: &mut impl DocumentCatalog,
+        postings: &mut HashMap<Term, HashMap<PathBuf, TermDocument>>,
+        document: ProcessedDocument,
+    ) {
+        registry.insert_or_update(
+            document.path.clone(),
+            document.token_length,
+            document.file_size_bytes,
+        );
+
+        for (term, doc_map) in Self::postings_for_document(&document) {
+            postings.entry(term).or_default().extend(doc_map);
+        }
+    }
     pub fn get_postings(&self, term: &Term) -> Option<&HashMap<PathBuf, TermDocument>> {
         self.postings.get(term)
     }
@@ -120,15 +179,19 @@ impl InvertedIndex {
     }
 
     pub fn num_docs(&self) -> usize {
-        self.doc_count
+        self.documents.len()
     }
 
     pub fn avg_doc_length(&self) -> f64 {
-        if self.doc_count == 0 {
-            return 0.0;
-        }
+        self.documents.avg_doc_length()
+    }
 
-        self.total_doc_length as f64 / self.doc_count as f64
+    pub fn doc_id(&self, path: &Path) -> Option<DocId> {
+        self.documents.doc_id(path)
+    }
+
+    pub fn document(&self, id: DocId) -> Option<&DocumentMetadata> {
+        self.documents.get(id)
     }
 
     pub fn doc_freq(&self, term: &Term) -> usize {
@@ -144,32 +207,17 @@ impl InvertedIndex {
         self.remove_document(path);
 
         if let Ok(content) = Self::read_document(path) {
-            Self::process_document(path, &content, transform_fn)
-                .into_iter()
-                .for_each(|(term, doc_map)| {
-                    self.postings.entry(term).or_default().extend(doc_map);
-                });
-            self.recalculate_stats();
+            let document = Self::analyze_document(path, &content, transform_fn);
+            Self::insert_processed_document(&mut self.documents, &mut self.postings, document);
         }
     }
 
     pub fn remove_document(&mut self, path: &Path) {
+        self.documents.remove(path);
         self.postings.retain(|_, documents| {
             documents.remove(path);
             !documents.is_empty()
         });
-        self.recalculate_stats();
-    }
-
-    fn recalculate_stats(&mut self) {
-        let mut unique_docs: HashMap<&PathBuf, usize> = HashMap::new();
-        for doc_map in self.postings.values() {
-            for (path, td) in doc_map {
-                unique_docs.entry(path).or_insert(td.length);
-            }
-        }
-        self.doc_count = unique_docs.len();
-        self.total_doc_length = unique_docs.values().map(|&l| l as u64).sum();
     }
 }
 
@@ -181,7 +229,9 @@ mod tests {
     };
 
     use super::InvertedIndex;
-    use crate::index::term::Term;
+    use crate::index::{document_registry::DocumentRegistry, term::Term};
+
+    type TestIndex = InvertedIndex<DocumentRegistry>;
 
     fn term_freqs(pairs: &[(&str, u32)]) -> HashMap<Term, u32> {
         pairs
@@ -207,7 +257,7 @@ mod tests {
         let transform_fn =
             |_: &str| -> HashMap<Term, u32> { term_freqs(&[("rust", 3), ("system", 1)]) };
 
-        let result = InvertedIndex::process_document(Path::new("test.rs"), "", &transform_fn);
+        let result = TestIndex::process_document(Path::new("test.rs"), "", &transform_fn);
 
         assert_eq!(get_term_doc(&result, "rust", "test.rs").term_freq, 3);
         assert_eq!(get_term_doc(&result, "system", "test.rs").term_freq, 1);
@@ -218,7 +268,7 @@ mod tests {
         let transform_fn =
             |_: &str| -> HashMap<Term, u32> { term_freqs(&[("rust", 3), ("system", 1)]) };
 
-        let result = InvertedIndex::process_document(Path::new("test.rs"), "", &transform_fn);
+        let result = TestIndex::process_document(Path::new("test.rs"), "", &transform_fn);
 
         assert_eq!(get_term_doc(&result, "rust", "test.rs").length, 4);
     }
@@ -228,7 +278,7 @@ mod tests {
         let transform_fn =
             |_: &str| -> HashMap<Term, u32> { term_freqs(&[("foo", 3), ("bar", 1), ("baz", 1)]) };
 
-        let result = InvertedIndex::process_document(Path::new("test.rs"), "", &transform_fn);
+        let result = TestIndex::process_document(Path::new("test.rs"), "", &transform_fn);
 
         let lengths: Vec<usize> = result
             .values()
@@ -288,6 +338,17 @@ mod tests {
         let index = build_index(&[("a.rs", &[("x", 3), ("y", 7)])]);
 
         assert_eq!(index.avg_doc_length(), 10.0);
+    }
+
+    #[test]
+    fn document_metadata_maps_id_back_to_path() {
+        let index = build_index(&[("a.rs", &[("x", 3), ("y", 7)])]);
+
+        let doc_id = index.doc_id(Path::new("a.rs")).unwrap();
+        let metadata = index.document(doc_id).unwrap();
+
+        assert_eq!(metadata.path, PathBuf::from("a.rs"));
+        assert_eq!(metadata.token_length, 10);
     }
 
     #[test]

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -1,5 +1,7 @@
+pub mod document_registry;
 pub mod inverted_index;
 pub mod term;
 
+pub use document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry};
 pub use inverted_index::{InvertedIndex, TermDocument};
 pub use term::Term;


### PR DESCRIPTION
- add `DocumentRegistry` and `DocumentMetadata` for stable compact `DocId` assignment
- add the `DocumentCatalog` trait so the index can swap registry implementations without changing callers
- use the registry as the source of truth for `num_docs` and `avg_doc_length`
- keep postings keyed by `PathBuf` for now to preserve current search behavior and eval metrics