### PR TITLE
refactor(index): key postings by doc id

### DIFF
--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -20,7 +20,7 @@ pub struct TermDocument {
 
 #[derive(Debug)]
 pub struct InvertedIndex<R = DocumentRegistry> {
-    postings: HashMap<Term, HashMap<PathBuf, TermDocument>>,
+    postings: HashMap<Term, HashMap<DocId, TermDocument>>,
     documents: R,
 }
 
@@ -34,19 +34,23 @@ struct ProcessedDocument {
 
 impl InvertedIndex<DocumentRegistry> {
     #[cfg(test)]
-    pub(crate) fn from_postings(postings: HashMap<Term, HashMap<PathBuf, TermDocument>>) -> Self {
-        let mut unique_docs: HashMap<PathBuf, usize> = HashMap::new();
-        for doc_map in postings.values() {
-            for (path, td) in doc_map {
-                unique_docs.entry(path.clone()).or_insert(td.length);
-            }
-        }
-
+    pub(crate) fn from_documents(docs: &[(&str, &[(&str, u32)])]) -> Self {
         let mut documents = DocumentRegistry::new();
-        let mut unique_docs: Vec<(PathBuf, usize)> = unique_docs.into_iter().collect();
-        unique_docs.sort_by(|(left, _), (right, _)| left.cmp(right));
-        for (path, length) in unique_docs {
-            documents.insert_or_update(path, length, 0);
+        let mut postings: HashMap<Term, HashMap<DocId, TermDocument>> = HashMap::new();
+
+        for &(path, terms) in docs {
+            let total_len: usize = terms.iter().map(|(_, c)| *c as usize).sum();
+            let doc_id = documents.insert_or_update(PathBuf::from(path), total_len, 0);
+
+            for &(term, freq) in terms {
+                postings.entry(Term(term.to_string())).or_default().insert(
+                    doc_id,
+                    TermDocument {
+                        length: total_len,
+                        term_freq: freq as usize,
+                    },
+                );
+            }
         }
 
         InvertedIndex {
@@ -105,7 +109,7 @@ impl<R> InvertedIndex<R>
 where
     R: DocumentCatalog,
 {
-    fn read_document(entry_path: &PathBuf) -> Result<String, std::io::Error> {
+    fn read_document(entry_path: &Path) -> Result<String, std::io::Error> {
         fs::read_to_string(entry_path)
     }
 
@@ -114,12 +118,14 @@ where
         entry_path: &Path,
         content: &str,
         transform_fn: &F,
-    ) -> HashMap<Term, HashMap<PathBuf, TermDocument>>
+    ) -> HashMap<Term, HashMap<DocId, TermDocument>>
     where
         F: Fn(&str) -> HashMap<Term, u32> + Sync,
     {
         let document = Self::analyze_document(entry_path, content, transform_fn);
-        Self::postings_for_document(&document)
+        let mut registry = DocumentRegistry::new();
+        let doc_id = registry.insert_or_update(document.path.clone(), document.token_length, 0);
+        Self::postings_for_document(doc_id, &document)
     }
 
     fn analyze_document<F>(entry_path: &Path, content: &str, transform_fn: &F) -> ProcessedDocument
@@ -138,13 +144,14 @@ where
     }
 
     fn postings_for_document(
+        doc_id: DocId,
         document: &ProcessedDocument,
-    ) -> HashMap<Term, HashMap<PathBuf, TermDocument>> {
-        let mut local_map: HashMap<Term, HashMap<PathBuf, TermDocument>> = HashMap::new();
+    ) -> HashMap<Term, HashMap<DocId, TermDocument>> {
+        let mut local_map: HashMap<Term, HashMap<DocId, TermDocument>> = HashMap::new();
 
         for (term, freq) in &document.term_frequencies {
             local_map.entry(term.clone()).or_default().insert(
-                document.path.clone(),
+                doc_id,
                 TermDocument {
                     length: document.token_length,
                     term_freq: *freq as usize,
@@ -157,24 +164,25 @@ where
 
     fn insert_processed_document(
         registry: &mut impl DocumentCatalog,
-        postings: &mut HashMap<Term, HashMap<PathBuf, TermDocument>>,
+        postings: &mut HashMap<Term, HashMap<DocId, TermDocument>>,
         document: ProcessedDocument,
     ) {
-        registry.insert_or_update(
+        let doc_id = registry.insert_or_update(
             document.path.clone(),
             document.token_length,
             document.file_size_bytes,
         );
 
-        for (term, doc_map) in Self::postings_for_document(&document) {
+        for (term, doc_map) in Self::postings_for_document(doc_id, &document) {
             postings.entry(term).or_default().extend(doc_map);
         }
     }
-    pub fn get_postings(&self, term: &Term) -> Option<&HashMap<PathBuf, TermDocument>> {
+
+    pub fn get_postings(&self, term: &Term) -> Option<&HashMap<DocId, TermDocument>> {
         self.postings.get(term)
     }
 
-    pub fn postings_iter(&self) -> impl Iterator<Item = (&Term, &HashMap<PathBuf, TermDocument>)> {
+    pub fn postings_iter(&self) -> impl Iterator<Item = (&Term, &HashMap<DocId, TermDocument>)> {
         self.postings.iter()
     }
 
@@ -200,22 +208,34 @@ where
             .map_or(0, |documents| documents.len())
     }
 
-    pub fn update<F>(&mut self, path: &PathBuf, transform_fn: &F)
+    pub fn update<F>(&mut self, path: &Path, transform_fn: &F)
     where
         F: Fn(&str) -> HashMap<Term, u32> + Sync,
     {
-        self.remove_document(path);
+        if let Some(doc_id) = self.documents.doc_id(path) {
+            self.remove_postings_for_doc(doc_id);
+        }
 
-        if let Ok(content) = Self::read_document(path) {
-            let document = Self::analyze_document(path, &content, transform_fn);
-            Self::insert_processed_document(&mut self.documents, &mut self.postings, document);
+        match Self::read_document(path) {
+            Ok(content) => {
+                let document = Self::analyze_document(path, &content, transform_fn);
+                Self::insert_processed_document(&mut self.documents, &mut self.postings, document);
+            }
+            Err(_) => {
+                self.documents.remove(path);
+            }
         }
     }
 
     pub fn remove_document(&mut self, path: &Path) {
-        self.documents.remove(path);
+        if let Some(metadata) = self.documents.remove(path) {
+            self.remove_postings_for_doc(metadata.id);
+        }
+    }
+
+    fn remove_postings_for_doc(&mut self, doc_id: DocId) {
         self.postings.retain(|_, documents| {
-            documents.remove(path);
+            documents.remove(&doc_id);
             !documents.is_empty()
         });
     }
@@ -229,7 +249,7 @@ mod tests {
     };
 
     use super::InvertedIndex;
-    use crate::index::{document_registry::DocumentRegistry, term::Term};
+    use crate::index::{DocId, document_registry::DocumentRegistry, term::Term};
 
     type TestIndex = InvertedIndex<DocumentRegistry>;
 
@@ -241,14 +261,14 @@ mod tests {
     }
 
     fn get_term_doc<'a>(
-        result: &'a HashMap<Term, HashMap<std::path::PathBuf, super::TermDocument>>,
+        result: &'a HashMap<Term, HashMap<DocId, super::TermDocument>>,
         term: &str,
-        path: &str,
+        doc_id: DocId,
     ) -> &'a super::TermDocument {
         result
             .get(&Term(term.to_string()))
             .unwrap()
-            .get(Path::new(path))
+            .get(&doc_id)
             .unwrap()
     }
 
@@ -258,9 +278,15 @@ mod tests {
             |_: &str| -> HashMap<Term, u32> { term_freqs(&[("rust", 3), ("system", 1)]) };
 
         let result = TestIndex::process_document(Path::new("test.rs"), "", &transform_fn);
+        let doc_id = *result
+            .get(&Term("rust".to_string()))
+            .unwrap()
+            .keys()
+            .next()
+            .unwrap();
 
-        assert_eq!(get_term_doc(&result, "rust", "test.rs").term_freq, 3);
-        assert_eq!(get_term_doc(&result, "system", "test.rs").term_freq, 1);
+        assert_eq!(get_term_doc(&result, "rust", doc_id).term_freq, 3);
+        assert_eq!(get_term_doc(&result, "system", doc_id).term_freq, 1);
     }
 
     #[test]
@@ -269,8 +295,14 @@ mod tests {
             |_: &str| -> HashMap<Term, u32> { term_freqs(&[("rust", 3), ("system", 1)]) };
 
         let result = TestIndex::process_document(Path::new("test.rs"), "", &transform_fn);
+        let doc_id = *result
+            .get(&Term("rust".to_string()))
+            .unwrap()
+            .keys()
+            .next()
+            .unwrap();
 
-        assert_eq!(get_term_doc(&result, "rust", "test.rs").length, 4);
+        assert_eq!(get_term_doc(&result, "rust", doc_id).length, 4);
     }
 
     #[test]
@@ -279,10 +311,16 @@ mod tests {
             |_: &str| -> HashMap<Term, u32> { term_freqs(&[("foo", 3), ("bar", 1), ("baz", 1)]) };
 
         let result = TestIndex::process_document(Path::new("test.rs"), "", &transform_fn);
+        let doc_id = *result
+            .get(&Term("foo".to_string()))
+            .unwrap()
+            .keys()
+            .next()
+            .unwrap();
 
         let lengths: Vec<usize> = result
             .values()
-            .filter_map(|docs| docs.get(Path::new("test.rs")))
+            .filter_map(|docs| docs.get(&doc_id))
             .map(|td| td.length)
             .collect();
 
@@ -290,20 +328,7 @@ mod tests {
     }
 
     fn build_index(docs: &[(&str, &[(&str, u32)])]) -> InvertedIndex {
-        let mut postings: HashMap<Term, HashMap<PathBuf, super::TermDocument>> = HashMap::new();
-        for &(path, terms) in docs {
-            let total_len: usize = terms.iter().map(|(_, c)| *c as usize).sum();
-            for &(term, freq) in terms {
-                postings.entry(Term(term.to_string())).or_default().insert(
-                    PathBuf::from(path),
-                    super::TermDocument {
-                        length: total_len,
-                        term_freq: freq as usize,
-                    },
-                );
-            }
-        }
-        InvertedIndex::from_postings(postings)
+        InvertedIndex::from_documents(docs)
     }
 
     #[test]
@@ -386,8 +411,16 @@ mod tests {
         assert_eq!(index.num_docs(), 2);
 
         let hello_docs = index.get_postings(&Term("hello".to_string())).unwrap();
-        assert!(hello_docs.contains_key(&PathBuf::from("src/main.rs")));
-        assert!(hello_docs.contains_key(&PathBuf::from("src/lib.rs")));
+        assert!(
+            index
+                .doc_id(Path::new("src/main.rs"))
+                .is_some_and(|id| hello_docs.contains_key(&id))
+        );
+        assert!(
+            index
+                .doc_id(Path::new("src/lib.rs"))
+                .is_some_and(|id| hello_docs.contains_key(&id))
+        );
     }
 
     #[test]
@@ -398,7 +431,10 @@ mod tests {
         let index = InvertedIndex::new(dir.path(), identity_transform, Some(dir.path()));
 
         let docs = index.get_postings(&Term("token".to_string())).unwrap();
-        let paths: Vec<&PathBuf> = docs.keys().collect();
+        let paths: Vec<&PathBuf> = docs
+            .keys()
+            .filter_map(|&doc_id| index.document(doc_id).map(|metadata| &metadata.path))
+            .collect();
 
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0], &PathBuf::from("a.txt"));
@@ -412,7 +448,8 @@ mod tests {
         let index = InvertedIndex::new(dir.path(), identity_transform, None::<&std::path::Path>);
 
         let docs = index.get_postings(&Term("token".to_string())).unwrap();
-        let path = docs.keys().next().unwrap();
+        let doc_id = docs.keys().next().unwrap();
+        let path = &index.document(*doc_id).unwrap().path;
 
         assert!(path.is_absolute());
     }
@@ -423,17 +460,20 @@ mod tests {
         write_temp_file(dir.path(), "a.txt", "old shared");
         let path = dir.path().join("a.txt");
         let mut index = InvertedIndex::new(dir.path(), identity_transform, None::<&Path>);
+        let original_doc_id = index.doc_id(&path).unwrap();
 
         write_temp_file(dir.path(), "a.txt", "new shared shared");
         index.update(&path, &identity_transform);
+        let updated_doc_id = index.doc_id(&path).unwrap();
 
         assert!(index.get_postings(&Term("old".to_string())).is_none());
 
         let new_docs = index.get_postings(&Term("new".to_string())).unwrap();
-        assert!(new_docs.contains_key(&path));
+        assert_eq!(updated_doc_id, original_doc_id);
+        assert!(new_docs.contains_key(&updated_doc_id));
 
         let shared_docs = index.get_postings(&Term("shared".to_string())).unwrap();
-        let shared = shared_docs.get(&path).unwrap();
+        let shared = shared_docs.get(&updated_doc_id).unwrap();
         assert_eq!(shared.length, 3);
         assert_eq!(shared.term_freq, 2);
         assert_eq!(index.num_docs(), 1);
@@ -467,8 +507,12 @@ mod tests {
         assert!(index.get_postings(&Term("only_a".to_string())).is_none());
 
         let shared_docs = index.get_postings(&Term("shared".to_string())).unwrap();
-        assert!(!shared_docs.contains_key(Path::new("a.rs")));
-        assert!(shared_docs.contains_key(Path::new("b.rs")));
+        assert!(index.doc_id(Path::new("a.rs")).is_none());
+        assert!(
+            index
+                .doc_id(Path::new("b.rs"))
+                .is_some_and(|id| shared_docs.contains_key(&id))
+        );
         assert_eq!(index.num_docs(), 1);
         assert_eq!(index.avg_doc_length(), 3.0);
     }

--- a/crates/core/src/ranking/bm25.rs
+++ b/crates/core/src/ranking/bm25.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
 use dashmap::DashMap;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     error::RankingError,
-    index::{InvertedIndex, TermDocument},
+    index::{DocId, InvertedIndex, TermDocument},
     query::Query,
     ranking::{scorer::Scorer, utils::idf},
 };
@@ -36,15 +36,15 @@ impl Scorer for BM25 {
         &self,
         inverted_index: &InvertedIndex,
         _: &Query,
-        documents: &HashMap<PathBuf, TermDocument>,
-        scores: &DashMap<PathBuf, f64>,
+        documents: &HashMap<DocId, TermDocument>,
+        scores: &DashMap<DocId, f64>,
     ) {
         let avgdl = inverted_index.avg_doc_length();
         let num_docs = inverted_index.num_docs();
 
         let idf = idf(num_docs, documents.len());
 
-        documents.par_iter().for_each(|(doc_path, term_doc)| {
+        documents.par_iter().for_each(|(doc_id, term_doc)| {
             let tf = term_doc.term_freq as f64;
             let doc_length = term_doc.length as f64;
             let score = idf * (tf * (self.hyper_params.k1 + 1.0))
@@ -52,7 +52,7 @@ impl Scorer for BM25 {
                     + self.hyper_params.k1
                         * (1.0 - self.hyper_params.b + self.hyper_params.b * doc_length / avgdl));
 
-            *scores.entry(doc_path.clone()).or_insert(0.0) += score;
+            *scores.entry(*doc_id).or_insert(0.0) += score;
         });
     }
 }
@@ -65,26 +65,18 @@ mod tests {
 
     use super::{BM25, BM25HyperParams};
     use crate::{
-        index::{InvertedIndex, Term, TermDocument},
+        index::{DocId, InvertedIndex, Term},
         query::Query,
         ranking::scorer::Scorer,
     };
 
     fn index_from(docs: &[(&str, &[(&str, u32)])]) -> InvertedIndex {
-        let mut postings: HashMap<Term, HashMap<PathBuf, TermDocument>> = HashMap::new();
-        for &(path, terms) in docs {
-            let total_len: usize = terms.iter().map(|(_, c)| *c as usize).sum();
-            for &(term, freq) in terms {
-                postings.entry(Term(term.to_string())).or_default().insert(
-                    PathBuf::from(path),
-                    TermDocument {
-                        length: total_len,
-                        term_freq: freq as usize,
-                    },
-                );
-            }
-        }
-        InvertedIndex::from_postings(postings)
+        InvertedIndex::from_documents(docs)
+    }
+
+    fn score_for_path(index: &InvertedIndex, scores: &DashMap<DocId, f64>, path: &str) -> f64 {
+        let doc_id = index.doc_id(PathBuf::from(path).as_path()).unwrap();
+        *scores.get(&doc_id).unwrap()
     }
 
     fn bm25() -> BM25 {
@@ -105,8 +97,8 @@ mod tests {
         let docs = index.get_postings(&Term("rust".to_string())).unwrap();
         bm25().score(&index, &query, docs, &scores);
 
-        let high = *scores.get(&PathBuf::from("high.rs")).unwrap();
-        let low = *scores.get(&PathBuf::from("low.rs")).unwrap();
+        let high = score_for_path(&index, &scores, "high.rs");
+        let low = score_for_path(&index, &scores, "low.rs");
         assert!(high > low, "higher tf should score higher: {high} vs {low}");
     }
 
@@ -129,8 +121,8 @@ mod tests {
             }
         }
 
-        let a = *scores.get(&PathBuf::from("a.rs")).unwrap();
-        let b = *scores.get(&PathBuf::from("b.rs")).unwrap();
+        let a = score_for_path(&index, &scores, "a.rs");
+        let b = score_for_path(&index, &scores, "b.rs");
         assert!(
             a > b,
             "doc matching rare term should score higher: a={a}, b={b}"
@@ -146,7 +138,7 @@ mod tests {
         let docs = index.get_postings(&Term("rust".to_string())).unwrap();
         bm25().score(&index, &query, docs, &scores);
 
-        let score = *scores.get(&PathBuf::from("a.rs")).unwrap();
+        let score = score_for_path(&index, &scores, "a.rs");
         assert!(score > 0.0, "BM25 score should be positive, got {score}");
     }
 }

--- a/crates/core/src/ranking/cosine_similarity.rs
+++ b/crates/core/src/ranking/cosine_similarity.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
 use dashmap::DashMap;
 use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{InvertedIndex, TermDocument},
+    index::{DocId, InvertedIndex, TermDocument},
     query::Query,
     ranking::{scorer::Scorer, utils::idf},
 };
@@ -16,8 +16,8 @@ impl Scorer for CosineSimilarity {
         &self,
         inverted_index: &InvertedIndex,
         query: &Query,
-        documents: &HashMap<PathBuf, TermDocument>,
-        scores: &DashMap<PathBuf, f64>,
+        documents: &HashMap<DocId, TermDocument>,
+        scores: &DashMap<DocId, f64>,
     ) {
         let num_docs = inverted_index.num_docs();
 
@@ -36,7 +36,7 @@ impl Scorer for CosineSimilarity {
         documents
             .iter()
             .par_bridge()
-            .for_each(|(doc_path, term_doc)| {
+            .for_each(|(doc_id, term_doc)| {
                 let tf = term_doc.term_freq as f64;
                 let dot_product = tf * term_idf * term_idf;
 
@@ -44,7 +44,7 @@ impl Scorer for CosineSimilarity {
                     .postings_iter()
                     .par_bridge()
                     .filter_map(|(_, doc_map)| {
-                        doc_map.get(doc_path).map(|td| {
+                        doc_map.get(doc_id).map(|td| {
                             let tf = td.term_freq as f64;
                             let doc_term_idf = idf(num_docs, doc_map.len());
                             let w = tf * doc_term_idf;
@@ -56,7 +56,7 @@ impl Scorer for CosineSimilarity {
 
                 let cosine_similarity = dot_product / (query_magnitude * doc_magnitude);
 
-                *scores.entry(doc_path.to_owned()).or_insert(0.0) += cosine_similarity;
+                *scores.entry(*doc_id).or_insert(0.0) += cosine_similarity;
             });
     }
 }
@@ -69,26 +69,13 @@ mod tests {
 
     use super::CosineSimilarity;
     use crate::{
-        index::{InvertedIndex, Term, TermDocument},
+        index::{InvertedIndex, Term},
         query::Query,
         ranking::{scorer::Scorer, utils::idf},
     };
 
     fn index_from(docs: &[(&str, &[(&str, u32)])]) -> InvertedIndex {
-        let mut postings: HashMap<Term, HashMap<PathBuf, TermDocument>> = HashMap::new();
-        for &(path, terms) in docs {
-            let total_len: usize = terms.iter().map(|(_, c)| *c as usize).sum();
-            for &(term, freq) in terms {
-                postings.entry(Term(term.to_string())).or_default().insert(
-                    PathBuf::from(path),
-                    TermDocument {
-                        length: total_len,
-                        term_freq: freq as usize,
-                    },
-                );
-            }
-        }
-        InvertedIndex::from_postings(postings)
+        InvertedIndex::from_documents(docs)
     }
 
     fn score_query(index: &InvertedIndex, query: &Query) -> HashMap<PathBuf, f64> {
@@ -98,7 +85,14 @@ mod tests {
                 CosineSimilarity.score(index, query, documents, &scores);
             }
         }
-        scores.into_iter().collect()
+        scores
+            .into_iter()
+            .filter_map(|(doc_id, score)| {
+                index
+                    .document(doc_id)
+                    .map(|metadata| (metadata.path.clone(), score))
+            })
+            .collect()
     }
 
     #[test]

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -4,7 +4,7 @@ use dashmap::DashMap;
 use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{InvertedIndex, TermDocument},
+    index::{DocId, InvertedIndex, TermDocument},
     query::Query,
     ranking::{BM25, BM25HyperParams, CosineSimilarity, TFIDF, get_configuration},
 };
@@ -52,8 +52,8 @@ pub trait Scorer: Send + Sync {
         &self,
         inverted_index: &InvertedIndex,
         query: &Query,
-        documents: &HashMap<PathBuf, TermDocument>,
-        scores: &DashMap<PathBuf, f64>,
+        documents: &HashMap<DocId, TermDocument>,
+        scores: &DashMap<DocId, f64>,
     );
 }
 
@@ -79,9 +79,11 @@ impl RankingAlgorithm for RankingAlgo {
             scores
                 .iter()
                 .par_bridge()
-                .map(|score| Score {
-                    doc_path: score.key().to_owned(),
-                    score: *score.value(),
+                .filter_map(|score| {
+                    inverted_index.document(*score.key()).map(|metadata| Score {
+                        doc_path: metadata.path.clone(),
+                        score: *score.value(),
+                    })
                 })
                 .collect(),
         )

--- a/crates/core/src/ranking/tf_idf.rs
+++ b/crates/core/src/ranking/tf_idf.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
 use dashmap::DashMap;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{InvertedIndex, TermDocument},
+    index::{DocId, InvertedIndex, TermDocument},
     query::Query,
     ranking::{scorer::Scorer, utils::idf},
 };
@@ -16,19 +16,19 @@ impl Scorer for TFIDF {
         &self,
         inverted_index: &InvertedIndex,
         _: &Query,
-        documents: &HashMap<PathBuf, TermDocument>,
-        scores: &DashMap<PathBuf, f64>,
+        documents: &HashMap<DocId, TermDocument>,
+        scores: &DashMap<DocId, f64>,
     ) {
         let num_docs = inverted_index.num_docs();
 
         documents
             .iter()
             .par_bridge()
-            .for_each(|(doc_path, term_doc)| {
+            .for_each(|(doc_id, term_doc)| {
                 let tf = term_doc.term_freq as f64 / term_doc.length as f64;
                 let idf = idf(num_docs, documents.len());
 
-                *scores.entry(doc_path.to_owned()).or_insert(0.0) += tf * idf;
+                *scores.entry(*doc_id).or_insert(0.0) += tf * idf;
             });
     }
 }
@@ -41,26 +41,18 @@ mod tests {
 
     use super::TFIDF;
     use crate::{
-        index::{InvertedIndex, Term, TermDocument},
+        index::{DocId, InvertedIndex, Term},
         query::Query,
         ranking::scorer::Scorer,
     };
 
     fn index_from(docs: &[(&str, &[(&str, u32)])]) -> InvertedIndex {
-        let mut postings: HashMap<Term, HashMap<PathBuf, TermDocument>> = HashMap::new();
-        for &(path, terms) in docs {
-            let total_len: usize = terms.iter().map(|(_, c)| *c as usize).sum();
-            for &(term, freq) in terms {
-                postings.entry(Term(term.to_string())).or_default().insert(
-                    PathBuf::from(path),
-                    TermDocument {
-                        length: total_len,
-                        term_freq: freq as usize,
-                    },
-                );
-            }
-        }
-        InvertedIndex::from_postings(postings)
+        InvertedIndex::from_documents(docs)
+    }
+
+    fn score_for_path(index: &InvertedIndex, scores: &DashMap<DocId, f64>, path: &str) -> f64 {
+        let doc_id = index.doc_id(PathBuf::from(path).as_path()).unwrap();
+        *scores.get(&doc_id).unwrap()
     }
 
     #[test]
@@ -76,8 +68,8 @@ mod tests {
         let docs = index.get_postings(&Term("rust".to_string())).unwrap();
         TFIDF.score(&index, &query, docs, &scores);
 
-        let dense = *scores.get(&PathBuf::from("dense.rs")).unwrap();
-        let sparse = *scores.get(&PathBuf::from("sparse.rs")).unwrap();
+        let dense = score_for_path(&index, &scores, "dense.rs");
+        let sparse = score_for_path(&index, &scores, "sparse.rs");
         assert!(
             dense > sparse,
             "higher term density should score higher: dense={dense}, sparse={sparse}"
@@ -93,7 +85,7 @@ mod tests {
         let docs = index.get_postings(&Term("rust".to_string())).unwrap();
         TFIDF.score(&index, &query, docs, &scores);
 
-        let score = *scores.get(&PathBuf::from("a.rs")).unwrap();
+        let score = score_for_path(&index, &scores, "a.rs");
         assert!(score > 0.0, "TF-IDF score should be positive, got {score}");
     }
 }


### PR DESCRIPTION
- key `InvertedIndex` postings by `DocId` instead of `PathBuf`
- keep `Score` and eval output path-based by resolving ids through `DocumentRegistry`
- preserve stable document ids across file updates while delete removes registry metadata
- update `BM25`, `TFIDF`, and `CosineSimilarity` scoring to accumulate by `DocId`