### PR TITLE
feat(ranking): respect query term weights

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -23,7 +23,7 @@ use repo_reaper_core::{
         metrics::TestQuery,
     },
     index::InvertedIndex,
-    query::Query,
+    query::AnalyzedQuery,
     ranking::RankingAlgo,
     tokenizer::n_gram_transform,
 };
@@ -178,7 +178,7 @@ fn main() -> Result<()> {
             break;
         }
 
-        let query = Query::new(&query, &config);
+        let query = AnalyzedQuery::new(&query, &config);
 
         let ranking = {
             let index = inverted_index
@@ -203,7 +203,7 @@ fn main() -> Result<()> {
 }
 
 fn log_query(
-    query: &Query,
+    query: &AnalyzedQuery,
     ranking: &Option<repo_reaper_core::ranking::Scored>,
     algo: &RankingAlgo,
     top_n: usize,

--- a/crates/core/src/evaluation/dataset.rs
+++ b/crates/core/src/evaluation/dataset.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-use crate::{config::Config, error::EvalError, query::Query};
+use crate::{config::Config, error::EvalError, query::AnalyzedQuery};
 
 #[derive(serde::Deserialize, Debug)]
 pub struct RawEvaluationData {
@@ -78,7 +78,7 @@ pub struct RawExample {
 }
 
 pub struct Example {
-    pub query: Query,
+    pub query: AnalyzedQuery,
     pub narrative: String,
     pub query_shape: Option<QueryShape>,
     pub results: Vec<ResultData>,
@@ -93,7 +93,7 @@ impl Example {
             .collect();
 
         Ok(Example {
-            query: Query::new(&raw.query, config),
+            query: AnalyzedQuery::new(&raw.query, config),
             narrative: raw.narrative,
             query_shape: raw.query_shape,
             results: results?,

--- a/crates/core/src/evaluation/metrics.rs
+++ b/crates/core/src/evaluation/metrics.rs
@@ -4,7 +4,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     index::InvertedIndex,
-    query::Query,
+    query::AnalyzedQuery,
     ranking::{RankingAlgo, Score},
 };
 
@@ -14,7 +14,7 @@ pub struct TestSet {
 }
 
 pub struct TestQuery {
-    pub query: Query,
+    pub query: AnalyzedQuery,
     pub relevant_docs: Vec<PathBuf>,
 }
 

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -1,28 +1,91 @@
 use std::collections::HashMap;
 
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-
 use crate::{config::Config, index::Term, tokenizer::n_gram_transform};
 
-#[derive(Clone)]
-pub struct Query(pub HashMap<Term, u32>);
+#[derive(Clone, Debug)]
+pub struct AnalyzedQuery {
+    original_text: String,
+    terms: HashMap<Term, QueryTerm>,
+}
 
-impl Query {
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct QueryTerm {
+    pub frequency: u32,
+    pub weight: f64,
+}
+
+impl AnalyzedQuery {
     pub fn new(query: &str, config: &Config) -> Self {
-        Self(n_gram_transform(query, config))
+        Self::from_frequencies(query.to_string(), n_gram_transform(query, config))
+    }
+
+    pub fn from_frequencies(
+        original_text: impl Into<String>,
+        frequencies: HashMap<Term, u32>,
+    ) -> Self {
+        let terms = frequencies
+            .into_iter()
+            .filter(|(_, frequency)| *frequency > 0)
+            .map(|(term, frequency)| {
+                (
+                    term,
+                    QueryTerm {
+                        frequency,
+                        weight: frequency as f64,
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            original_text: original_text.into(),
+            terms,
+        }
+    }
+
+    pub fn from_weights(original_text: impl Into<String>, weights: HashMap<Term, f64>) -> Self {
+        let terms = weights
+            .into_iter()
+            .filter(|(_, weight)| *weight > 0.0)
+            .map(|(term, weight)| {
+                (
+                    term,
+                    QueryTerm {
+                        frequency: 1,
+                        weight,
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            original_text: original_text.into(),
+            terms,
+        }
+    }
+
+    pub fn original_text(&self) -> &str {
+        &self.original_text
+    }
+
+    pub fn terms(&self) -> impl Iterator<Item = (&Term, &QueryTerm)> {
+        self.terms.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.terms.len()
     }
 }
 
-impl std::fmt::Display for Query {
+impl std::fmt::Display for AnalyzedQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.0
-                .par_iter()
-                .map(|(term, _)| term.0.clone())
-                .collect::<Vec<_>>()
-                .join(" ")
-        )
+        let mut terms: Vec<&str> = self.terms.keys().map(|term| term.0.as_str()).collect();
+        terms.sort_unstable();
+
+        write!(f, "{}", terms.join(" "))
     }
 }

--- a/crates/core/src/ranking/bm25.rs
+++ b/crates/core/src/ranking/bm25.rs
@@ -5,8 +5,8 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     error::RankingError,
-    index::{DocId, InvertedIndex, TermDocument},
-    query::Query,
+    index::{DocId, InvertedIndex, Term, TermDocument},
+    query::{AnalyzedQuery, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
 
@@ -35,7 +35,9 @@ impl Scorer for BM25 {
     fn score(
         &self,
         inverted_index: &InvertedIndex,
-        _: &Query,
+        _: &AnalyzedQuery,
+        _: &Term,
+        query_term: QueryTerm,
         documents: &HashMap<DocId, TermDocument>,
         scores: &DashMap<DocId, f64>,
     ) {
@@ -47,7 +49,7 @@ impl Scorer for BM25 {
         documents.par_iter().for_each(|(doc_id, term_doc)| {
             let tf = term_doc.term_freq as f64;
             let doc_length = term_doc.length as f64;
-            let score = idf * (tf * (self.hyper_params.k1 + 1.0))
+            let score = query_term.weight * idf * (tf * (self.hyper_params.k1 + 1.0))
                 / (tf
                     + self.hyper_params.k1
                         * (1.0 - self.hyper_params.b + self.hyper_params.b * doc_length / avgdl));
@@ -66,7 +68,7 @@ mod tests {
     use super::{BM25, BM25HyperParams};
     use crate::{
         index::{DocId, InvertedIndex, Term},
-        query::Query,
+        query::AnalyzedQuery,
         ranking::scorer::Scorer,
     };
 
@@ -91,11 +93,19 @@ mod tests {
             ("high.rs", &[("rust", 10), ("other", 1)]),
             ("low.rs", &[("rust", 1), ("other", 1)]),
         ]);
-        let query = Query(HashMap::from([(Term("rust".to_string()), 1)]));
+        let term = Term("rust".to_string());
+        let query = AnalyzedQuery::from_frequencies("rust", HashMap::from([(term.clone(), 1)]));
         let scores = DashMap::new();
 
-        let docs = index.get_postings(&Term("rust".to_string())).unwrap();
-        bm25().score(&index, &query, docs, &scores);
+        let docs = index.get_postings(&term).unwrap();
+        bm25().score(
+            &index,
+            &query,
+            &term,
+            *query.terms().next().unwrap().1,
+            docs,
+            &scores,
+        );
 
         let high = score_for_path(&index, &scores, "high.rs");
         let low = score_for_path(&index, &scores, "low.rs");
@@ -109,15 +119,18 @@ mod tests {
             ("b.rs", &[("common", 1)]),
             ("c.rs", &[("common", 1)]),
         ]);
-        let query = Query(HashMap::from([
-            (Term("rare".to_string()), 1),
-            (Term("common".to_string()), 1),
-        ]));
+        let query = AnalyzedQuery::from_frequencies(
+            "rare common",
+            HashMap::from([
+                (Term("rare".to_string()), 1),
+                (Term("common".to_string()), 1),
+            ]),
+        );
 
         let scores = DashMap::new();
-        for term in query.0.keys() {
+        for (term, query_term) in query.terms() {
             if let Some(docs) = index.get_postings(term) {
-                bm25().score(&index, &query, docs, &scores);
+                bm25().score(&index, &query, term, *query_term, docs, &scores);
             }
         }
 
@@ -132,13 +145,58 @@ mod tests {
     #[test]
     fn scores_are_positive() {
         let index = index_from(&[("a.rs", &[("rust", 3)])]);
-        let query = Query(HashMap::from([(Term("rust".to_string()), 1)]));
+        let term = Term("rust".to_string());
+        let query = AnalyzedQuery::from_frequencies("rust", HashMap::from([(term.clone(), 1)]));
         let scores = DashMap::new();
 
-        let docs = index.get_postings(&Term("rust".to_string())).unwrap();
-        bm25().score(&index, &query, docs, &scores);
+        let docs = index.get_postings(&term).unwrap();
+        bm25().score(
+            &index,
+            &query,
+            &term,
+            *query.terms().next().unwrap().1,
+            docs,
+            &scores,
+        );
 
         let score = score_for_path(&index, &scores, "a.rs");
         assert!(score > 0.0, "BM25 score should be positive, got {score}");
+    }
+
+    #[test]
+    fn query_weight_scales_score() {
+        let index = index_from(&[("a.rs", &[("rust", 3)])]);
+        let term = Term("rust".to_string());
+        let low_query = AnalyzedQuery::from_weights("rust", HashMap::from([(term.clone(), 1.0)]));
+        let high_query =
+            AnalyzedQuery::from_weights("rust^3", HashMap::from([(term.clone(), 3.0)]));
+        let docs = index.get_postings(&term).unwrap();
+
+        let low_scores = DashMap::new();
+        bm25().score(
+            &index,
+            &low_query,
+            &term,
+            *low_query.terms().next().unwrap().1,
+            docs,
+            &low_scores,
+        );
+
+        let high_scores = DashMap::new();
+        bm25().score(
+            &index,
+            &high_query,
+            &term,
+            *high_query.terms().next().unwrap().1,
+            docs,
+            &high_scores,
+        );
+
+        let low = score_for_path(&index, &low_scores, "a.rs");
+        let high = score_for_path(&index, &high_scores, "a.rs");
+        assert!(
+            high > low,
+            "higher query weight should increase score: {high} vs {low}"
+        );
     }
 }

--- a/crates/core/src/ranking/cosine_similarity.rs
+++ b/crates/core/src/ranking/cosine_similarity.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use dashmap::DashMap;
-use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
+use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{DocId, InvertedIndex, TermDocument},
-    query::Query,
+    index::{DocId, InvertedIndex, Term, TermDocument},
+    query::{AnalyzedQuery, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
 
@@ -15,18 +15,21 @@ impl Scorer for CosineSimilarity {
     fn score(
         &self,
         inverted_index: &InvertedIndex,
-        query: &Query,
+        query: &AnalyzedQuery,
+        _: &Term,
+        query_term: QueryTerm,
         documents: &HashMap<DocId, TermDocument>,
         scores: &DashMap<DocId, f64>,
     ) {
         let num_docs = inverted_index.num_docs();
 
         let query_magnitude = query
-            .0
-            .par_iter()
-            .map(|(term, _)| {
+            .terms()
+            .par_bridge()
+            .map(|(term, query_term)| {
                 let idf = idf(num_docs, inverted_index.doc_freq(term));
-                idf * idf
+                let weight = query_term.weight * idf;
+                weight * weight
             })
             .sum::<f64>()
             .sqrt();
@@ -38,11 +41,15 @@ impl Scorer for CosineSimilarity {
             .par_bridge()
             .for_each(|(doc_id, term_doc)| {
                 let tf = term_doc.term_freq as f64;
-                let dot_product = tf * term_idf * term_idf;
+                let dot_product = query_term.weight * tf * term_idf * term_idf;
 
                 let Some(doc_magnitude) = inverted_index.document_norm(*doc_id) else {
                     return;
                 };
+
+                if query_magnitude == 0.0 || doc_magnitude == 0.0 {
+                    return;
+                }
 
                 let cosine_similarity = dot_product / (query_magnitude * doc_magnitude);
 
@@ -60,7 +67,7 @@ mod tests {
     use super::CosineSimilarity;
     use crate::{
         index::{InvertedIndex, Term},
-        query::Query,
+        query::AnalyzedQuery,
         ranking::{scorer::Scorer, utils::idf},
     };
 
@@ -68,11 +75,11 @@ mod tests {
         InvertedIndex::from_documents(docs)
     }
 
-    fn score_query(index: &InvertedIndex, query: &Query) -> HashMap<PathBuf, f64> {
+    fn score_query(index: &InvertedIndex, query: &AnalyzedQuery) -> HashMap<PathBuf, f64> {
         let scores = DashMap::new();
-        for term in query.0.keys() {
+        for (term, query_term) in query.terms() {
             if let Some(documents) = index.get_postings(term) {
-                CosineSimilarity.score(index, query, documents, &scores);
+                CosineSimilarity.score(index, query, term, *query_term, documents, &scores);
             }
         }
         scores
@@ -91,7 +98,8 @@ mod tests {
             ("a.rs", &[("rare", 1), ("common", 1)]),
             ("b.rs", &[("common", 1)]),
         ]);
-        let query = Query(HashMap::from([(Term("rare".to_string()), 1)]));
+        let query =
+            AnalyzedQuery::from_frequencies("rare", HashMap::from([(Term("rare".to_string()), 1)]));
 
         let scores = score_query(&index, &query);
         let score_a = scores[&PathBuf::from("a.rs")];
@@ -110,7 +118,8 @@ mod tests {
     #[test]
     fn single_term_query_and_doc_yields_one() {
         let index = index_from(&[("a.rs", &[("rust", 3)])]);
-        let query = Query(HashMap::from([(Term("rust".to_string()), 1)]));
+        let query =
+            AnalyzedQuery::from_frequencies("rust", HashMap::from([(Term("rust".to_string()), 1)]));
 
         let scores = score_query(&index, &query);
 
@@ -126,7 +135,8 @@ mod tests {
             ("a.rs", &[("rust", 5), ("code", 2)]),
             ("b.rs", &[("rust", 1), ("java", 3)]),
         ]);
-        let query = Query(HashMap::from([(Term("rust".to_string()), 1)]));
+        let query =
+            AnalyzedQuery::from_frequencies("rust", HashMap::from([(Term("rust".to_string()), 1)]));
 
         for (path, s) in score_query(&index, &query) {
             assert!(
@@ -135,5 +145,35 @@ mod tests {
                 path.display()
             );
         }
+    }
+
+    #[test]
+    fn repeated_query_term_shifts_similarity_toward_matching_document() {
+        let index = index_from(&[
+            ("rust.rs", &[("rust", 2), ("code", 1)]),
+            ("code.rs", &[("rust", 1), ("code", 2)]),
+        ]);
+
+        let balanced = AnalyzedQuery::from_frequencies(
+            "rust code",
+            HashMap::from([(Term("rust".to_string()), 1), (Term("code".to_string()), 1)]),
+        );
+        let rust_weighted = AnalyzedQuery::from_frequencies(
+            "rust rust code",
+            HashMap::from([(Term("rust".to_string()), 2), (Term("code".to_string()), 1)]),
+        );
+
+        let balanced_scores = score_query(&index, &balanced);
+        let weighted_scores = score_query(&index, &rust_weighted);
+        let rust_path = PathBuf::from("rust.rs");
+        let code_path = PathBuf::from("code.rs");
+
+        let balanced_gap = balanced_scores[&rust_path] - balanced_scores[&code_path];
+        let weighted_gap = weighted_scores[&rust_path] - weighted_scores[&code_path];
+
+        assert!(
+            weighted_gap > balanced_gap,
+            "repeated query term should shift cosine score toward matching doc: {weighted_gap} vs {balanced_gap}"
+        );
     }
 }

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use dashmap::DashMap;
-use rayon::iter::{IntoParallelRefIterator, ParallelBridge, ParallelIterator};
+use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{DocId, InvertedIndex, TermDocument},
-    query::Query,
+    index::{DocId, InvertedIndex, Term, TermDocument},
+    query::{AnalyzedQuery, QueryTerm},
     ranking::{BM25, BM25HyperParams, CosineSimilarity, TFIDF, get_configuration},
 };
 
@@ -44,21 +44,23 @@ pub enum RankingAlgo {
 }
 
 pub trait RankingAlgorithm {
-    fn score(&self, inverted_index: &InvertedIndex, query: &Query) -> Scored;
+    fn score(&self, inverted_index: &InvertedIndex, query: &AnalyzedQuery) -> Scored;
 }
 
 pub trait Scorer: Send + Sync {
     fn score(
         &self,
         inverted_index: &InvertedIndex,
-        query: &Query,
+        query: &AnalyzedQuery,
+        term: &Term,
+        query_term: QueryTerm,
         documents: &HashMap<DocId, TermDocument>,
         scores: &DashMap<DocId, f64>,
     );
 }
 
 impl RankingAlgorithm for RankingAlgo {
-    fn score(&self, inverted_index: &InvertedIndex, query: &Query) -> Scored {
+    fn score(&self, inverted_index: &InvertedIndex, query: &AnalyzedQuery) -> Scored {
         let scorer: Box<dyn Scorer> = match self {
             RankingAlgo::CosineSimilarity => Box::new(CosineSimilarity),
             RankingAlgo::BM25(hyper_params) => Box::new(BM25 {
@@ -69,9 +71,9 @@ impl RankingAlgorithm for RankingAlgo {
 
         let scores = DashMap::new();
 
-        query.0.par_iter().for_each(|(term, _)| {
+        query.terms().par_bridge().for_each(|(term, query_term)| {
             if let Some(documents) = inverted_index.get_postings(term) {
-                scorer.score(inverted_index, query, documents, &scores)
+                scorer.score(inverted_index, query, term, *query_term, documents, &scores)
             }
         });
 
@@ -94,10 +96,10 @@ impl RankingAlgo {
     pub fn rank(
         &self,
         inverted_index: &InvertedIndex,
-        query: &Query,
+        query: &AnalyzedQuery,
         top_n: usize,
     ) -> Option<Scored> {
-        if query.0.is_empty() {
+        if query.is_empty() {
             return None;
         }
 
@@ -129,5 +131,69 @@ impl FromStr for RankingAlgo {
             "tfidf" => Ok(RankingAlgo::TFIDF),
             _ => Err(format!("{} is not a valid ranking algorithm", s)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, path::PathBuf};
+
+    use super::{BM25HyperParams, RankingAlgo};
+    use crate::{
+        index::{InvertedIndex, Term},
+        query::AnalyzedQuery,
+    };
+
+    fn index() -> InvertedIndex {
+        InvertedIndex::from_documents(&[
+            ("rust.rs", &[("rust", 5), ("code", 1)]),
+            ("code.rs", &[("rust", 1), ("code", 5)]),
+        ])
+    }
+
+    fn query_with_weights(rust: f64, code: f64) -> AnalyzedQuery {
+        AnalyzedQuery::from_weights(
+            "weighted query",
+            HashMap::from([
+                (Term("rust".to_string()), rust),
+                (Term("code".to_string()), code),
+            ]),
+        )
+    }
+
+    fn bm25() -> RankingAlgo {
+        RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 })
+    }
+
+    #[test]
+    fn bm25_query_weights_change_ranking_order() {
+        let index = index();
+        let rust_weighted = query_with_weights(4.0, 1.0);
+        let code_weighted = query_with_weights(1.0, 4.0);
+
+        let rust_top = bm25().rank(&index, &rust_weighted, 1).unwrap().0;
+        let code_top = bm25().rank(&index, &code_weighted, 1).unwrap().0;
+
+        assert_eq!(rust_top[0].doc_path, PathBuf::from("rust.rs"));
+        assert_eq!(code_top[0].doc_path, PathBuf::from("code.rs"));
+    }
+
+    #[test]
+    fn tfidf_query_weights_change_ranking_order() {
+        let index = index();
+        let rust_weighted = query_with_weights(4.0, 1.0);
+        let code_weighted = query_with_weights(1.0, 4.0);
+
+        let rust_top = RankingAlgo::TFIDF
+            .rank(&index, &rust_weighted, 1)
+            .unwrap()
+            .0;
+        let code_top = RankingAlgo::TFIDF
+            .rank(&index, &code_weighted, 1)
+            .unwrap()
+            .0;
+
+        assert_eq!(rust_top[0].doc_path, PathBuf::from("rust.rs"));
+        assert_eq!(code_top[0].doc_path, PathBuf::from("code.rs"));
     }
 }

--- a/crates/core/src/ranking/tf_idf.rs
+++ b/crates/core/src/ranking/tf_idf.rs
@@ -4,8 +4,8 @@ use dashmap::DashMap;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{DocId, InvertedIndex, TermDocument},
-    query::Query,
+    index::{DocId, InvertedIndex, Term, TermDocument},
+    query::{AnalyzedQuery, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
 
@@ -15,7 +15,9 @@ impl Scorer for TFIDF {
     fn score(
         &self,
         inverted_index: &InvertedIndex,
-        _: &Query,
+        _: &AnalyzedQuery,
+        _: &Term,
+        query_term: QueryTerm,
         documents: &HashMap<DocId, TermDocument>,
         scores: &DashMap<DocId, f64>,
     ) {
@@ -28,7 +30,7 @@ impl Scorer for TFIDF {
                 let tf = term_doc.term_freq as f64 / term_doc.length as f64;
                 let idf = idf(num_docs, documents.len());
 
-                *scores.entry(*doc_id).or_insert(0.0) += tf * idf;
+                *scores.entry(*doc_id).or_insert(0.0) += query_term.weight * tf * idf;
             });
     }
 }
@@ -42,7 +44,7 @@ mod tests {
     use super::TFIDF;
     use crate::{
         index::{DocId, InvertedIndex, Term},
-        query::Query,
+        query::AnalyzedQuery,
         ranking::scorer::Scorer,
     };
 
@@ -62,11 +64,19 @@ mod tests {
             ("dense.rs", &[("rust", 5), ("other", 1)]),
             ("sparse.rs", &[("rust", 1), ("other", 10)]),
         ]);
-        let query = Query(HashMap::from([(Term("rust".to_string()), 1)]));
+        let term = Term("rust".to_string());
+        let query = AnalyzedQuery::from_frequencies("rust", HashMap::from([(term.clone(), 1)]));
         let scores = DashMap::new();
 
-        let docs = index.get_postings(&Term("rust".to_string())).unwrap();
-        TFIDF.score(&index, &query, docs, &scores);
+        let docs = index.get_postings(&term).unwrap();
+        TFIDF.score(
+            &index,
+            &query,
+            &term,
+            *query.terms().next().unwrap().1,
+            docs,
+            &scores,
+        );
 
         let dense = score_for_path(&index, &scores, "dense.rs");
         let sparse = score_for_path(&index, &scores, "sparse.rs");
@@ -79,13 +89,58 @@ mod tests {
     #[test]
     fn scores_are_positive() {
         let index = index_from(&[("a.rs", &[("rust", 3)])]);
-        let query = Query(HashMap::from([(Term("rust".to_string()), 1)]));
+        let term = Term("rust".to_string());
+        let query = AnalyzedQuery::from_frequencies("rust", HashMap::from([(term.clone(), 1)]));
         let scores = DashMap::new();
 
-        let docs = index.get_postings(&Term("rust".to_string())).unwrap();
-        TFIDF.score(&index, &query, docs, &scores);
+        let docs = index.get_postings(&term).unwrap();
+        TFIDF.score(
+            &index,
+            &query,
+            &term,
+            *query.terms().next().unwrap().1,
+            docs,
+            &scores,
+        );
 
         let score = score_for_path(&index, &scores, "a.rs");
         assert!(score > 0.0, "TF-IDF score should be positive, got {score}");
+    }
+
+    #[test]
+    fn query_weight_scales_score() {
+        let index = index_from(&[("a.rs", &[("rust", 3)])]);
+        let term = Term("rust".to_string());
+        let low_query = AnalyzedQuery::from_weights("rust", HashMap::from([(term.clone(), 1.0)]));
+        let high_query =
+            AnalyzedQuery::from_weights("rust^3", HashMap::from([(term.clone(), 3.0)]));
+        let docs = index.get_postings(&term).unwrap();
+
+        let low_scores = DashMap::new();
+        TFIDF.score(
+            &index,
+            &low_query,
+            &term,
+            *low_query.terms().next().unwrap().1,
+            docs,
+            &low_scores,
+        );
+
+        let high_scores = DashMap::new();
+        TFIDF.score(
+            &index,
+            &high_query,
+            &term,
+            *high_query.terms().next().unwrap().1,
+            docs,
+            &high_scores,
+        );
+
+        let low = score_for_path(&index, &low_scores, "a.rs");
+        let high = score_for_path(&index, &high_scores, "a.rs");
+        assert!(
+            high > low,
+            "higher query weight should increase score: {high} vs {low}"
+        );
     }
 }


### PR DESCRIPTION
- replace the raw `Query` frequency map with an explicit `AnalyzedQuery` carrying original text, term frequency, and query weight
- thread weighted query terms through the shared `Scorer` boundary for `BM25`, `TFIDF`, and `CosineSimilarity`
- make repeated query terms and explicit query weights influence scoring and ranking order
- keep the change scoped to ranking correctness without adding external search libraries or unrelated roadmap items