### PR TITLE
feat(cli): add corpus stats reporting

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,7 +22,7 @@ use repo_reaper_core::{
         EvaluationCorpus, EvaluationData, RawEvaluationData, TestSet, dataset::Relevance,
         metrics::TestQuery,
     },
-    index::InvertedIndex,
+    index::{CorpusStats, InvertedIndex},
     query::AnalyzedQuery,
     ranking::RankingAlgo,
     tokenizer::n_gram_transform,
@@ -53,6 +53,9 @@ struct Args {
     /// Evaluation data JSON
     #[clap(long, default_value = "./data/train.json")]
     eval_data: PathBuf,
+    /// Print corpus statistics for the indexed directory and exit
+    #[clap(long, default_value = "false")]
+    stats: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -102,6 +105,15 @@ fn main() -> Result<()> {
             .map_err(|_| anyhow!("index lock poisoned"))?
             .num_docs()
     );
+
+    if args.stats {
+        let stats = inverted_index
+            .lock()
+            .map_err(|_| anyhow!("index lock poisoned"))?
+            .corpus_stats(10);
+        print_corpus_stats(&stats);
+        return Ok(());
+    }
 
     let (tx, rx) = std::sync::mpsc::channel();
     let rx = Arc::new(Mutex::new(rx));
@@ -200,6 +212,26 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_corpus_stats(stats: &CorpusStats) {
+    println!("documents: {}", stats.document_count);
+    println!("total tokens: {}", stats.total_token_count);
+    println!("vocabulary size: {}", stats.vocabulary_size);
+    println!("singleton terms: {}", stats.singleton_term_count);
+    println!("high-frequency terms:");
+
+    if stats.high_frequency_terms.is_empty() {
+        println!("  none");
+        return;
+    }
+
+    for summary in &stats.high_frequency_terms {
+        println!(
+            "  {}: collection_frequency={}, document_frequency={}",
+            summary.term, summary.collection_frequency, summary.document_frequency
+        );
+    }
 }
 
 fn log_query(

--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -52,6 +52,7 @@ pub trait DocumentCatalog {
     fn doc_id(&self, path: &Path) -> Option<DocId>;
     fn len(&self) -> usize;
     fn is_empty(&self) -> bool;
+    fn total_token_length(&self) -> u64;
     fn avg_doc_length(&self) -> f64;
 }
 
@@ -113,6 +114,10 @@ impl DocumentCatalog for DocumentRegistry {
 
     fn is_empty(&self) -> bool {
         self.documents.is_empty()
+    }
+
+    fn total_token_length(&self) -> u64 {
+        self.total_token_length
     }
 
     fn avg_doc_length(&self) -> f64 {

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -21,6 +21,22 @@ pub struct TermDocument {
     pub term_freq: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorpusStats {
+    pub document_count: usize,
+    pub total_token_count: u64,
+    pub vocabulary_size: usize,
+    pub singleton_term_count: usize,
+    pub high_frequency_terms: Vec<TermFrequencySummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TermFrequencySummary {
+    pub term: String,
+    pub collection_frequency: usize,
+    pub document_frequency: usize,
+}
+
 #[derive(Debug)]
 pub struct InvertedIndex<R = DocumentRegistry> {
     postings: HashMap<Term, HashMap<DocId, TermDocument>>,
@@ -206,6 +222,40 @@ where
 
     pub fn avg_doc_length(&self) -> f64 {
         self.documents.avg_doc_length()
+    }
+
+    pub fn corpus_stats(&self, high_frequency_limit: usize) -> CorpusStats {
+        let mut term_summaries: Vec<TermFrequencySummary> = self
+            .postings
+            .iter()
+            .map(|(term, documents)| TermFrequencySummary {
+                term: term.0.clone(),
+                collection_frequency: documents.values().map(|doc| doc.term_freq).sum(),
+                document_frequency: documents.len(),
+            })
+            .collect();
+
+        let singleton_term_count = term_summaries
+            .iter()
+            .filter(|summary| summary.collection_frequency == 1)
+            .count();
+
+        term_summaries.sort_by(|left, right| {
+            right
+                .collection_frequency
+                .cmp(&left.collection_frequency)
+                .then_with(|| right.document_frequency.cmp(&left.document_frequency))
+                .then_with(|| left.term.cmp(&right.term))
+        });
+        term_summaries.truncate(high_frequency_limit);
+
+        CorpusStats {
+            document_count: self.documents.len(),
+            total_token_count: self.documents.total_token_length(),
+            vocabulary_size: self.postings.len(),
+            singleton_term_count,
+            high_frequency_terms: term_summaries,
+        }
     }
 
     pub fn doc_id(&self, path: &Path) -> Option<DocId> {
@@ -440,6 +490,47 @@ mod tests {
         let index = build_index(&[]);
 
         assert_eq!(index.avg_doc_length(), 0.0);
+    }
+
+    #[test]
+    fn corpus_stats_reports_document_and_term_totals() {
+        let index = build_index(&[
+            ("a.rs", &[("shared", 2), ("only_a", 1)]),
+            ("b.rs", &[("shared", 1), ("only_b", 4)]),
+        ]);
+
+        let stats = index.corpus_stats(10);
+
+        assert_eq!(stats.document_count, 2);
+        assert_eq!(stats.total_token_count, 8);
+        assert_eq!(stats.vocabulary_size, 3);
+        assert_eq!(stats.singleton_term_count, 1);
+    }
+
+    #[test]
+    fn corpus_stats_reports_high_frequency_terms_in_stable_order() {
+        let index = build_index(&[
+            ("a.rs", &[("shared", 2), ("alpha", 3), ("zeta", 1)]),
+            ("b.rs", &[("shared", 2), ("beta", 3)]),
+        ]);
+
+        let stats = index.corpus_stats(3);
+        let terms: Vec<_> = stats
+            .high_frequency_terms
+            .iter()
+            .map(|summary| {
+                (
+                    summary.term.as_str(),
+                    summary.collection_frequency,
+                    summary.document_frequency,
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            terms,
+            vec![("shared", 4, 2), ("alpha", 3, 1), ("beta", 3, 1)]
+        );
     }
 
     fn write_temp_file(dir: &std::path::Path, name: &str, content: &str) {

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -3,5 +3,5 @@ pub mod inverted_index;
 pub mod term;
 
 pub use document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry};
-pub use inverted_index::{InvertedIndex, TermDocument};
+pub use inverted_index::{CorpusStats, InvertedIndex, TermDocument, TermFrequencySummary};
 pub use term::Term;


### PR DESCRIPTION
- add `CorpusStats` and `TermFrequencySummary` derived from existing `DocumentRegistry` and posting data
- expose `--stats` as a small cli mode that indexes the requested directory, prints corpus measurements, and exits
- report document count, total token count, vocabulary size, singleton terms, and top high-frequency terms
- cover synthetic indexes with focused tests for corpus totals and stable high-frequency ordering