### PR TITLE
fix(cli): harden evaluation workdir setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "rust-stemmers",
  "serde_json",
  "stop-words",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,3 +17,6 @@ rust-stemmers = "^1.2"
 stop-words = "^0.10"
 serde_json = "^1.0"
 chrono = "^0.4.44"
+
+[dev-dependencies]
+tempfile = "^3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     fs::{self, OpenOptions},
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::Command,
     sync::{Arc, Mutex},
     thread,
@@ -53,6 +53,12 @@ struct Args {
     /// Evaluation data JSON
     #[clap(long, default_value = "./data/train.json")]
     eval_data: PathBuf,
+    /// Directory used for a cloned Git evaluation corpus
+    #[clap(long, default_value = "./data/repo")]
+    eval_workdir: PathBuf,
+    /// Remove and reclone the Git evaluation workdir before evaluating
+    #[clap(long, default_value = "false")]
+    fresh: bool,
     /// Print corpus statistics for the indexed directory and exit
     #[clap(long, default_value = "false")]
     stats: bool,
@@ -292,10 +298,8 @@ fn evaluate_training(args: &Args, config: &ReaperConfig) -> Result<()> {
     let index_root = match &evaluation_data.corpus {
         EvaluationCorpus::Tree { root } => root.clone(),
         EvaluationCorpus::Git { repo, commit, root } => {
-            let path = PathBuf::from("./data/repo");
-            if path.exists() {
-                fs::remove_dir_all(&path).context("failed to clean previous evaluation repo")?;
-            }
+            let path = args.eval_workdir.clone();
+            prepare_git_eval_workdir(&path, args.fresh)?;
 
             let clone_output = Command::new("git")
                 .arg("clone")
@@ -368,6 +372,35 @@ fn evaluate_training(args: &Args, config: &ReaperConfig) -> Result<()> {
     Ok(())
 }
 
+fn prepare_git_eval_workdir(path: &Path, fresh: bool) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if !fresh {
+        bail!(
+            "evaluation workdir {} already exists; pass --fresh to remove and reclone it, or choose a different --eval-workdir",
+            path.display()
+        );
+    }
+
+    if !path.is_dir() {
+        bail!(
+            "refusing to remove non-directory evaluation workdir {}",
+            path.display()
+        );
+    }
+
+    fs::remove_dir_all(path).with_context(|| {
+        format!(
+            "failed to clean previous evaluation workdir {}",
+            path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
 fn ensure_command_succeeded(command: &str, output: std::process::Output) -> Result<()> {
     if output.status.success() {
         return Ok(());
@@ -378,4 +411,59 @@ fn ensure_command_succeeded(command: &str, output: std::process::Output) -> Resu
         status = output.status,
         stderr = String::from_utf8_lossy(&output.stderr).trim()
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prepare_git_eval_workdir;
+
+    #[test]
+    fn prepare_git_eval_workdir_allows_missing_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo");
+
+        prepare_git_eval_workdir(&path, false).unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn prepare_git_eval_workdir_refuses_existing_directory_without_fresh() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo");
+        std::fs::create_dir(&path).unwrap();
+
+        let error = prepare_git_eval_workdir(&path, false).unwrap_err();
+
+        assert!(error.to_string().contains("already exists; pass --fresh"));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn prepare_git_eval_workdir_removes_existing_directory_with_fresh() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join("README.md"), "old clone").unwrap();
+
+        prepare_git_eval_workdir(&path, true).unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn prepare_git_eval_workdir_refuses_non_directory_with_fresh() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo");
+        std::fs::write(&path, "not a directory").unwrap();
+
+        let error = prepare_git_eval_workdir(&path, true).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to remove non-directory")
+        );
+        assert!(path.exists());
+    }
 }

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ test *ARGS:
 # run the checked-in repo-native evaluation smoke set
 [group("dev")]
 eval-smoke:
-    cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10
+    cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10 --fresh
 
 # compile the workspace
 [group("dev")]


### PR DESCRIPTION
- add `--eval-workdir` so git-backed evaluation clones can use an explicit workspace
- add `--fresh` to make removing and recloning an existing evaluation workdir an explicit opt-in
- keep default evaluation runs from deleting `./data/repo` unless fresh setup is requested
- update `just eval-smoke` to request fresh setup for the checked-in repo-native evaluation