### PR TITLE
feat(bench): add core search benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 .DS_Store
 /data/repo
 query_log.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +19,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -98,6 +113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +145,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -191,6 +239,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +298,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dashmap"
@@ -321,6 +411,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +456,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -521,10 +628,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -668,6 +795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +824,34 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -765,6 +926,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "repo-reaper-cli"
 version = "0.1.0"
 dependencies = [
@@ -785,6 +975,7 @@ name = "repo-reaper-core"
 version = "0.1.0"
 dependencies = [
  "config",
+ "criterion",
  "dashmap",
  "rayon",
  "rust-stemmers",
@@ -989,6 +1180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1336,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1423,6 +1634,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,4 +20,9 @@ dashmap = "^6"
 thiserror = "^2.0"
 
 [dev-dependencies]
+criterion = "^0.5"
 tempfile = "^3"
+
+[[bench]]
+name = "search_bench"
+harness = false

--- a/crates/core/benches/search_bench.rs
+++ b/crates/core/benches/search_bench.rs
@@ -1,0 +1,207 @@
+use std::{collections::HashSet, fs, path::Path};
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use repo_reaper_core::{
+    config::Config,
+    index::InvertedIndex,
+    query::AnalyzedQuery,
+    ranking::{BM25HyperParams, RankingAlgo},
+    tokenizer::n_gram_transform,
+};
+use rust_stemmers::{Algorithm, Stemmer};
+use tempfile::TempDir;
+
+const CORPUS_SEED: u64 = 0x5eed_cafe;
+const DOC_COUNT: usize = 256;
+const TOKENS_PER_DOC: usize = 240;
+
+fn bench_config() -> Config {
+    Config {
+        n_grams: 1,
+        stemmer: Stemmer::create(Algorithm::English),
+        stop_words: stop_words::get(stop_words::LANGUAGE::English)
+            .iter()
+            .map(|word| word.to_string())
+            .collect::<HashSet<_>>(),
+    }
+}
+
+fn bm25() -> RankingAlgo {
+    RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 })
+}
+
+fn deterministic_corpus(doc_count: usize, tokens_per_doc: usize, seed: u64) -> Vec<String> {
+    let mut rng = Lcg::new(seed);
+    let vocabulary = [
+        "repository",
+        "index",
+        "token",
+        "parser",
+        "query",
+        "ranking",
+        "update",
+        "delete",
+        "watcher",
+        "document",
+        "metadata",
+        "registry",
+        "posting",
+        "score",
+        "metric",
+        "precision",
+        "recall",
+        "cosine",
+        "bm25",
+        "evaluation",
+        "config",
+        "error",
+        "path",
+        "rust",
+        "module",
+        "search",
+        "freshness",
+        "latency",
+        "corpus",
+        "snippet",
+        "evidence",
+        "identifier",
+    ];
+
+    (0..doc_count)
+        .map(|doc_id| {
+            let mut tokens = Vec::with_capacity(tokens_per_doc + 3);
+            tokens.push("repository".to_string());
+            tokens.push(format!("module_{doc_id}"));
+
+            for _ in 0..tokens_per_doc {
+                let word = vocabulary[rng.next_usize(vocabulary.len())];
+                tokens.push(word.to_string());
+            }
+
+            tokens.push(format!("identifier_{}", doc_id % 17));
+            tokens.join(" ")
+        })
+        .collect()
+}
+
+fn write_corpus(root: &Path, docs: &[String]) {
+    fs::create_dir_all(root.join("src")).expect("create synthetic corpus directory");
+
+    for (idx, content) in docs.iter().enumerate() {
+        fs::write(root.join("src").join(format!("module_{idx}.rs")), content)
+            .expect("write synthetic corpus document");
+    }
+}
+
+fn corpus_fixture() -> TempDir {
+    let dir = tempfile::tempdir().expect("create synthetic corpus tempdir");
+    let docs = deterministic_corpus(DOC_COUNT, TOKENS_PER_DOC, CORPUS_SEED);
+    write_corpus(dir.path(), &docs);
+    dir
+}
+
+fn build_index(root: &Path, config: &Config) -> InvertedIndex {
+    InvertedIndex::new(
+        root,
+        |content: &str| n_gram_transform(content, config),
+        Some(root),
+    )
+}
+
+fn bench_tokenization(c: &mut Criterion) {
+    let config = bench_config();
+    let docs = deterministic_corpus(1, TOKENS_PER_DOC * 8, CORPUS_SEED);
+    let content = docs.first().expect("synthetic corpus has one document");
+
+    c.bench_function("tokenization/ngram_unigram", |b| {
+        b.iter(|| n_gram_transform(black_box(content), black_box(&config)));
+    });
+}
+
+fn bench_index_build(c: &mut Criterion) {
+    let config = bench_config();
+    let corpus = corpus_fixture();
+
+    c.bench_with_input(
+        BenchmarkId::new("index_build", DOC_COUNT),
+        &corpus,
+        |b, corpus| {
+            b.iter(|| build_index(black_box(corpus.path()), black_box(&config)));
+        },
+    );
+}
+
+fn bench_ranked_search(c: &mut Criterion) {
+    let config = bench_config();
+    let corpus = corpus_fixture();
+    let index = build_index(corpus.path(), &config);
+    let query = AnalyzedQuery::new("repository token parser update", &config);
+    let bm25 = bm25();
+
+    let mut group = c.benchmark_group("ranked_search");
+    group.bench_function("bm25", |b| {
+        b.iter(|| bm25.rank(black_box(&index), black_box(&query), black_box(10)));
+    });
+    group.bench_function("cosine", |b| {
+        b.iter(|| {
+            RankingAlgo::CosineSimilarity.rank(black_box(&index), black_box(&query), black_box(10))
+        });
+    });
+    group.bench_function("tfidf", |b| {
+        b.iter(|| RankingAlgo::TFIDF.rank(black_box(&index), black_box(&query), black_box(10)));
+    });
+    group.finish();
+}
+
+fn bench_index_update(c: &mut Criterion) {
+    let config = bench_config();
+
+    c.bench_function("index_update/single_document", |b| {
+        b.iter_batched(
+            || {
+                let corpus = corpus_fixture();
+                let index = build_index(corpus.path(), &config);
+                (corpus, index)
+            },
+            |(corpus, mut index)| {
+                let path = corpus.path().join("src/module_0.rs");
+                fs::write(
+                    &path,
+                    "repository token parser update update update deterministic replacement",
+                )
+                .expect("rewrite synthetic corpus document");
+
+                index.update(&path, &|content: &str| n_gram_transform(content, &config));
+                black_box(index);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+}
+
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_usize(&mut self, upper_bound: usize) -> usize {
+        self.state = self
+            .state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        (self.state % upper_bound as u64) as usize
+    }
+}
+
+criterion_group!(
+    benches,
+    bench_tokenization,
+    bench_index_build,
+    bench_ranked_search,
+    bench_index_update
+);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -30,3 +30,8 @@ eval-smoke:
 [group("dev")]
 build:
     cargo build
+
+# run the core Criterion benchmark harness
+[group("dev")]
+bench:
+    cargo bench -p repo-reaper-core --bench search_bench


### PR DESCRIPTION
- adds a `criterion` benchmark target for `repo-reaper-core`
- benchmarks `n_gram_transform`, index build, `bm25`, cosine, and `tfidf` search, plus single-document index updates
- uses a deterministic synthetic corpus generator with a fixed seed for repeatable local comparisons
- adds `just bench` and ignores nested `target/` output from criterion runs