### PR TITLE
feat(eval): add relevance regression comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "rayon",
  "repo-reaper-core",
  "rust-stemmers",
+ "serde",
  "serde_json",
  "stop-words",
  "tempfile",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ notify = "^8"
 rayon = "^1.11"
 rust-stemmers = "^1.2"
 stop-words = "^0.10"
+serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = "^0.4.44"
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,8 +19,8 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use repo_reaper_core::{
     config::Config as ReaperConfig,
     evaluation::{
-        EvaluationCorpus, EvaluationData, RawEvaluationData, TestSet, dataset::Relevance,
-        metrics::TestQuery,
+        Evaluation, EvaluationCorpus, EvaluationData, EvaluationReport, RawEvaluationData, TestSet,
+        dataset::Relevance, metrics::TestQuery,
     },
     index::{CorpusStats, InvertedIndex},
     query::AnalyzedQuery,
@@ -50,6 +50,12 @@ struct Args {
     /// Evaluation output format
     #[clap(long, value_enum, default_value = "pretty")]
     eval_format: EvalOutputFormat,
+    /// Compare the current evaluation report against a saved JSON baseline
+    #[clap(long)]
+    eval_compare: Option<PathBuf>,
+    /// Allowed negative delta before eval comparison fails
+    #[clap(long, default_value = "0")]
+    eval_regression_threshold: f64,
     /// Evaluation data JSON
     #[clap(long, default_value = "./data/train.json")]
     eval_data: PathBuf,
@@ -68,6 +74,57 @@ struct Args {
 enum EvalOutputFormat {
     Pretty,
     Json,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct EvaluationComparison {
+    file_retrieval: FileRetrievalComparison,
+    evidence: EvidenceComparison,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct FileRetrievalComparison {
+    aggregate: EvaluationDelta,
+    queries: Vec<QueryEvaluationDelta>,
+    regressions: Vec<MetricRegression>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct QueryEvaluationDelta {
+    query: String,
+    metrics: EvaluationDelta,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct EvaluationDelta {
+    precision_at_k: MetricDelta,
+    recall_at_k: MetricDelta,
+    mean_average_precision: MetricDelta,
+    mean_reciprocal_rank: MetricDelta,
+    normalized_discounted_cumulative_gain: MetricDelta,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct MetricDelta {
+    baseline: f64,
+    current: f64,
+    delta: f64,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct MetricRegression {
+    scope: String,
+    metric: String,
+    delta: f64,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct EvidenceComparison {
+    status: String,
+    baseline_queries_with_evidence: usize,
+    current_queries_with_evidence: usize,
+    baseline_total_evidence_spans: usize,
+    current_total_evidence_spans: usize,
 }
 
 fn main() -> Result<()> {
@@ -351,20 +408,60 @@ fn evaluate_training(args: &Args, config: &ReaperConfig) -> Result<()> {
                     .par_iter()
                     .map(|(path, _)| path.clone())
                     .collect::<Vec<_>>(),
+                evidence_span_count: example
+                    .results
+                    .iter()
+                    .map(|result| result.evidence.len())
+                    .sum(),
             }
         })
         .collect();
 
-    let evaluation = TestSet {
+    let evaluation_report = TestSet {
         ranking_algorithm: args.ranking_algorithm.clone(),
         queries,
     }
     .evaluate_report(&inverted_index, args.top_n);
 
+    if let Some(baseline_path) = &args.eval_compare {
+        let baseline = read_evaluation_baseline(baseline_path)?;
+        let mut comparison = compare_evaluation_reports(&baseline, &evaluation_report);
+        comparison.file_retrieval.regressions =
+            collect_regressions(&comparison, args.eval_regression_threshold);
+
+        match args.eval_format {
+            EvalOutputFormat::Pretty => print_evaluation_comparison(&comparison),
+            EvalOutputFormat::Json => {
+                let json = serde_json::to_string_pretty(&comparison)
+                    .context("failed to serialize evaluation comparison")?;
+                println!("{json}");
+            }
+        }
+
+        if !comparison.file_retrieval.regressions.is_empty() {
+            bail!(
+                "evaluation regressed beyond threshold {}: {}",
+                args.eval_regression_threshold,
+                comparison
+                    .file_retrieval
+                    .regressions
+                    .iter()
+                    .map(|regression| format!(
+                        "{} {} ({:+.4})",
+                        regression.scope, regression.metric, regression.delta
+                    ))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        return Ok(());
+    }
+
     match args.eval_format {
-        EvalOutputFormat::Pretty => print_pretty_evaluation(&evaluation),
+        EvalOutputFormat::Pretty => print_pretty_evaluation(&evaluation_report),
         EvalOutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&evaluation)
+            let json = serde_json::to_string_pretty(&evaluation_report)
                 .context("failed to serialize evaluation report")?;
             println!("{json}");
         }
@@ -374,14 +471,14 @@ fn evaluate_training(args: &Args, config: &ReaperConfig) -> Result<()> {
 }
 
 fn print_pretty_evaluation(evaluation: &repo_reaper_core::evaluation::metrics::EvaluationReport) {
-    println!("{}", evaluation.aggregate);
+    println!("{}", evaluation.file_retrieval.aggregate);
 
-    if evaluation.slices.is_empty() {
+    if evaluation.file_retrieval.slices.is_empty() {
         return;
     }
 
     println!("\nquery-shape slices:");
-    for slice in &evaluation.slices {
+    for slice in &evaluation.file_retrieval.slices {
         println!(
             "  {shape} ({family}, n={count}): MAP@{k}: {map:.4}, MRR@{k}: {mrr:.4}, NDCG@{k}: {ndcg:.4}",
             shape = slice.query_shape,
@@ -393,6 +490,202 @@ fn print_pretty_evaluation(evaluation: &repo_reaper_core::evaluation::metrics::E
             ndcg = slice.metrics.normalized_discounted_cumulative_gain,
         );
     }
+}
+
+fn read_evaluation_baseline(path: &Path) -> Result<EvaluationReport> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read eval baseline from {}", path.display()))?;
+
+    if let Ok(report) = serde_json::from_str::<EvaluationReport>(&content) {
+        return Ok(report);
+    }
+
+    let aggregate: Evaluation = serde_json::from_str(&content)
+        .context("failed to parse eval baseline as an evaluation report or legacy aggregate")?;
+
+    Ok(EvaluationReport {
+        file_retrieval: repo_reaper_core::evaluation::metrics::FileRetrievalReport {
+            aggregate,
+            slices: Vec::new(),
+            queries: Vec::new(),
+        },
+        evidence: repo_reaper_core::evaluation::metrics::EvidenceReport {
+            status: repo_reaper_core::evaluation::metrics::EvidenceReportStatus::NotScored,
+            queries_with_evidence: 0,
+            total_evidence_spans: 0,
+        },
+    })
+}
+
+fn compare_evaluation_reports(
+    baseline: &EvaluationReport,
+    current: &EvaluationReport,
+) -> EvaluationComparison {
+    let aggregate = compare_evaluations(
+        &baseline.file_retrieval.aggregate,
+        &current.file_retrieval.aggregate,
+    );
+    let queries = current
+        .file_retrieval
+        .queries
+        .iter()
+        .filter_map(|current_query| {
+            let baseline_query = baseline
+                .file_retrieval
+                .queries
+                .iter()
+                .find(|baseline_query| baseline_query.query == current_query.query)?;
+
+            Some(QueryEvaluationDelta {
+                query: current_query.query.clone(),
+                metrics: compare_evaluations(&baseline_query.metrics, &current_query.metrics),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    EvaluationComparison {
+        file_retrieval: FileRetrievalComparison {
+            aggregate,
+            queries,
+            regressions: Vec::new(),
+        },
+        evidence: EvidenceComparison {
+            status: "not_scored".to_string(),
+            baseline_queries_with_evidence: baseline.evidence.queries_with_evidence,
+            current_queries_with_evidence: current.evidence.queries_with_evidence,
+            baseline_total_evidence_spans: baseline.evidence.total_evidence_spans,
+            current_total_evidence_spans: current.evidence.total_evidence_spans,
+        },
+    }
+}
+
+fn compare_evaluations(baseline: &Evaluation, current: &Evaluation) -> EvaluationDelta {
+    EvaluationDelta {
+        precision_at_k: metric_delta(baseline.precision_at_k, current.precision_at_k),
+        recall_at_k: metric_delta(baseline.recall_at_k, current.recall_at_k),
+        mean_average_precision: metric_delta(
+            baseline.mean_average_precision,
+            current.mean_average_precision,
+        ),
+        mean_reciprocal_rank: metric_delta(
+            baseline.mean_reciprocal_rank,
+            current.mean_reciprocal_rank,
+        ),
+        normalized_discounted_cumulative_gain: metric_delta(
+            baseline.normalized_discounted_cumulative_gain,
+            current.normalized_discounted_cumulative_gain,
+        ),
+    }
+}
+
+fn metric_delta(baseline: f64, current: f64) -> MetricDelta {
+    let raw_delta = current - baseline;
+    let delta = if raw_delta.abs() < 1e-12 {
+        0.0
+    } else {
+        raw_delta
+    };
+
+    MetricDelta {
+        baseline,
+        current,
+        delta,
+    }
+}
+
+fn collect_regressions(comparison: &EvaluationComparison, threshold: f64) -> Vec<MetricRegression> {
+    let mut regressions = Vec::new();
+    push_key_metric_regressions(
+        &mut regressions,
+        "aggregate",
+        &comparison.file_retrieval.aggregate,
+        threshold,
+    );
+
+    for query in &comparison.file_retrieval.queries {
+        push_key_metric_regressions(&mut regressions, &query.query, &query.metrics, threshold);
+    }
+
+    regressions
+}
+
+fn push_key_metric_regressions(
+    regressions: &mut Vec<MetricRegression>,
+    scope: &str,
+    delta: &EvaluationDelta,
+    threshold: f64,
+) {
+    for (metric, value) in [
+        ("recall_at_k", delta.recall_at_k.delta),
+        ("mean_average_precision", delta.mean_average_precision.delta),
+        ("mean_reciprocal_rank", delta.mean_reciprocal_rank.delta),
+        (
+            "normalized_discounted_cumulative_gain",
+            delta.normalized_discounted_cumulative_gain.delta,
+        ),
+    ] {
+        if value < -threshold {
+            regressions.push(MetricRegression {
+                scope: scope.to_string(),
+                metric: metric.to_string(),
+                delta: value,
+            });
+        }
+    }
+}
+
+fn print_evaluation_comparison(comparison: &EvaluationComparison) {
+    println!("file retrieval aggregate deltas:");
+    print_metric_delta("P", &comparison.file_retrieval.aggregate.precision_at_k);
+    print_metric_delta("R", &comparison.file_retrieval.aggregate.recall_at_k);
+    print_metric_delta(
+        "MAP",
+        &comparison.file_retrieval.aggregate.mean_average_precision,
+    );
+    print_metric_delta(
+        "MRR",
+        &comparison.file_retrieval.aggregate.mean_reciprocal_rank,
+    );
+    print_metric_delta(
+        "NDCG",
+        &comparison
+            .file_retrieval
+            .aggregate
+            .normalized_discounted_cumulative_gain,
+    );
+
+    if comparison.file_retrieval.queries.is_empty() {
+        println!("per-query deltas: no comparable query baselines");
+    } else {
+        println!("per-query deltas:");
+        for query in &comparison.file_retrieval.queries {
+            println!("  {}", query.query);
+            print_metric_delta("  MAP", &query.metrics.mean_average_precision);
+            print_metric_delta("  MRR", &query.metrics.mean_reciprocal_rank);
+            print_metric_delta(
+                "  NDCG",
+                &query.metrics.normalized_discounted_cumulative_gain,
+            );
+        }
+    }
+
+    println!(
+        "evidence metrics: {} (queries with evidence: {} -> {}, spans: {} -> {})",
+        comparison.evidence.status,
+        comparison.evidence.baseline_queries_with_evidence,
+        comparison.evidence.current_queries_with_evidence,
+        comparison.evidence.baseline_total_evidence_spans,
+        comparison.evidence.current_total_evidence_spans
+    );
+}
+
+fn print_metric_delta(name: &str, delta: &MetricDelta) {
+    println!(
+        "  {name}: {baseline:.4} -> {current:.4} ({delta:+.4})",
+        baseline = delta.baseline,
+        current = delta.current,
+        delta = delta.delta
+    );
 }
 
 fn prepare_git_eval_workdir(path: &Path, fresh: bool) -> Result<()> {

--- a/crates/core/src/evaluation/metrics.rs
+++ b/crates/core/src/evaluation/metrics.rs
@@ -22,9 +22,10 @@ pub struct TestQuery {
     pub query: AnalyzedQuery,
     pub query_shape: QueryShape,
     pub relevant_docs: Vec<PathBuf>,
+    pub evidence_span_count: usize,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Evaluation {
     pub k: usize,
     pub precision_at_k: f64,
@@ -53,7 +54,7 @@ impl Default for Evaluation {
     }
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricFamily {
     ManyRelevantDocuments,
@@ -99,7 +100,7 @@ impl fmt::Display for QueryShape {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct EvaluationSlice {
     pub query_shape: QueryShape,
     pub metric_family: MetricFamily,
@@ -108,11 +109,42 @@ pub struct EvaluationSlice {
     pub metrics: Evaluation,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct EvaluationReport {
+    pub file_retrieval: FileRetrievalReport,
+    pub evidence: EvidenceReport,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct FileRetrievalReport {
     #[serde(flatten)]
     pub aggregate: Evaluation,
+    #[serde(default)]
     pub slices: Vec<EvaluationSlice>,
+    #[serde(default)]
+    pub queries: Vec<QueryEvaluation>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct QueryEvaluation {
+    pub query: String,
+    pub query_shape: QueryShape,
+    pub metrics: Evaluation,
+    pub relevant_docs: Vec<PathBuf>,
+    pub retrieved_docs: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct EvidenceReport {
+    pub status: EvidenceReportStatus,
+    pub queries_with_evidence: usize,
+    pub total_evidence_spans: usize,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceReportStatus {
+    NotScored,
 }
 
 pub fn evaluate_query_at_k(
@@ -274,13 +306,9 @@ impl fmt::Display for Evaluation {
 
 impl TestSet {
     pub fn evaluate(&self, inverted_index: &InvertedIndex, top_n: usize) -> Evaluation {
-        let evaluations = self.query_evaluations(inverted_index, top_n);
-        let evaluations: Vec<_> = evaluations
-            .into_iter()
-            .map(|(_, evaluation)| evaluation)
-            .collect();
-
-        average_evaluations(&evaluations)
+        self.evaluate_report(inverted_index, top_n)
+            .file_retrieval
+            .aggregate
     }
 
     pub fn evaluate_report(
@@ -288,41 +316,72 @@ impl TestSet {
         inverted_index: &InvertedIndex,
         top_n: usize,
     ) -> EvaluationReport {
-        let evaluations = self.query_evaluations(inverted_index, top_n);
-        let aggregate_evaluations: Vec<_> = evaluations
-            .iter()
-            .map(|(_, evaluation)| evaluation.clone())
+        let queries: Vec<QueryEvaluation> = self
+            .queries
+            .par_iter()
+            .map(|query| evaluate_test_query(&self.ranking_algorithm, inverted_index, query, top_n))
             .collect();
 
+        let aggregate = average_evaluations(
+            &queries
+                .iter()
+                .map(|query| query.metrics.clone())
+                .collect::<Vec<_>>(),
+        );
+
+        let queries_with_evidence = self
+            .queries
+            .iter()
+            .filter(|query| query.evidence_span_count > 0)
+            .count();
+        let total_evidence_spans = self
+            .queries
+            .iter()
+            .map(|query| query.evidence_span_count)
+            .sum();
+        let slice_inputs = queries
+            .iter()
+            .map(|query| (query.query_shape, query.metrics.clone()))
+            .collect::<Vec<_>>();
+
         EvaluationReport {
-            aggregate: average_evaluations(&aggregate_evaluations),
-            slices: evaluation_slices(&evaluations),
+            file_retrieval: FileRetrievalReport {
+                aggregate,
+                slices: evaluation_slices(&slice_inputs),
+                queries,
+            },
+            evidence: EvidenceReport {
+                status: EvidenceReportStatus::NotScored,
+                queries_with_evidence,
+                total_evidence_spans,
+            },
         }
     }
+}
 
-    fn query_evaluations(
-        &self,
-        inverted_index: &InvertedIndex,
-        top_n: usize,
-    ) -> Vec<(QueryShape, Evaluation)> {
-        self.queries
-            .par_iter()
-            .map(|query| {
-                let ranked_docs =
-                    match self
-                        .ranking_algorithm
-                        .rank(inverted_index, &query.query, top_n)
-                    {
-                        Some(ranking) => ranking.0,
-                        None => return (query.query_shape, Evaluation::zero(top_n)),
-                    };
+fn evaluate_test_query(
+    ranking_algorithm: &RankingAlgo,
+    inverted_index: &InvertedIndex,
+    query: &TestQuery,
+    top_n: usize,
+) -> QueryEvaluation {
+    let ranked_docs = ranking_algorithm
+        .rank(inverted_index, &query.query, top_n)
+        .map(|ranking| ranking.0)
+        .unwrap_or_default();
 
-                (
-                    query.query_shape,
-                    evaluate_query_at_k(&ranked_docs, &query.relevant_docs, top_n),
-                )
-            })
-            .collect()
+    let metrics = evaluate_query_at_k(&ranked_docs, &query.relevant_docs, top_n);
+    let retrieved_docs = ranked_docs
+        .into_iter()
+        .map(|score| score.doc_path)
+        .collect::<Vec<_>>();
+
+    QueryEvaluation {
+        query: query.query.original_text().to_string(),
+        query_shape: query.query_shape,
+        metrics,
+        relevant_docs: query.relevant_docs.clone(),
+        retrieved_docs,
     }
 }
 
@@ -330,8 +389,14 @@ impl TestSet {
 mod tests {
     use std::path::PathBuf;
 
-    use super::{Evaluation, MetricFamily, average_evaluations, evaluate_query_at_k};
-    use crate::{evaluation::dataset::QueryShape, ranking::Score};
+    use super::{
+        Evaluation, MetricFamily, TestQuery, TestSet, average_evaluations, evaluate_query_at_k,
+    };
+    use crate::{
+        evaluation::dataset::QueryShape,
+        query::AnalyzedQuery,
+        ranking::{RankingAlgo, Score},
+    };
 
     fn scored(paths: &[&str]) -> Vec<Score> {
         paths
@@ -510,5 +575,35 @@ mod tests {
                 "metric must be in [0, 1], got {val}"
             );
         }
+    }
+
+    #[test]
+    fn evaluate_report_includes_query_metrics_and_evidence_boundary() {
+        let queries = vec![TestQuery {
+            query: AnalyzedQuery::from_frequencies("missing query", Default::default()),
+            query_shape: QueryShape::Identifier,
+            relevant_docs: relevant(&["a.rs"]),
+            evidence_span_count: 2,
+        }];
+        let test_set = TestSet {
+            ranking_algorithm: RankingAlgo::TFIDF,
+            queries,
+        };
+        let temp = tempfile::tempdir().unwrap();
+        let index = crate::index::InvertedIndex::new(
+            temp.path(),
+            |_| std::collections::HashMap::new(),
+            None,
+        );
+
+        let report = test_set.evaluate_report(&index, 10);
+
+        assert_eq!(report.file_retrieval.queries[0].query, "missing query");
+        assert_eq!(
+            report.file_retrieval.slices[0].query_shape,
+            QueryShape::Identifier
+        );
+        assert_eq!(report.evidence.queries_with_evidence, 1);
+        assert_eq!(report.evidence.total_evidence_spans, 2);
     }
 }

--- a/crates/core/src/evaluation/mod.rs
+++ b/crates/core/src/evaluation/mod.rs
@@ -2,4 +2,4 @@ pub mod dataset;
 pub mod metrics;
 
 pub use dataset::{EvaluationCorpus, EvaluationData, RawEvaluationData};
-pub use metrics::{Evaluation, TestQuery, TestSet};
+pub use metrics::{Evaluation, EvaluationReport, TestQuery, TestSet};

--- a/justfile
+++ b/justfile
@@ -55,6 +55,11 @@ audit:
 eval-smoke:
     cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10 --fresh
 
+# compare the checked-in repo-native evaluation set against a saved JSON baseline
+[group("dev")]
+eval-compare baseline:
+    baseline="{{baseline}}"; cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10 --fresh --eval-compare "${baseline#baseline=}"
+
 # compile the workspace
 [group("dev")]
 build:


### PR DESCRIPTION
- adds structured `EvaluationReport` output with aggregate and per-query file retrieval metrics
- adds `--eval-compare` and `--eval-regression-threshold` so current eval runs can be compared against saved json baselines
- keeps `evidence` metrics separate as `not_scored` while preserving evidence span counts for future highlight scoring
- adds `just eval-compare baseline=<file>` for the repo-native eval set