### PR TITLE
feat(regex): add literal trigram search

### DIFF
--- a/crates/core/src/regex_search/corpus.rs
+++ b/crates/core/src/regex_search/corpus.rs
@@ -1,0 +1,52 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use walkdir::WalkDir;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorpusDocument {
+    pub path: PathBuf,
+    pub content: String,
+}
+
+pub trait RegexCorpus {
+    fn documents(&self) -> Vec<CorpusDocument>;
+    fn read_document(&self, path: &Path) -> Option<String>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FileSystemCorpus {
+    root: PathBuf,
+}
+
+impl FileSystemCorpus {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+}
+
+impl RegexCorpus for FileSystemCorpus {
+    fn documents(&self) -> Vec<CorpusDocument> {
+        let mut paths = WalkDir::new(&self.root)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| entry.path().to_path_buf())
+            .collect::<Vec<_>>();
+
+        paths.sort();
+        paths
+            .into_iter()
+            .filter_map(|path| {
+                let content = fs::read_to_string(&path).ok()?;
+                Some(CorpusDocument { path, content })
+            })
+            .collect()
+    }
+
+    fn read_document(&self, path: &Path) -> Option<String> {
+        fs::read_to_string(path).ok()
+    }
+}

--- a/crates/core/src/regex_search/engine.rs
+++ b/crates/core/src/regex_search/engine.rs
@@ -1,0 +1,62 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use regex::Regex;
+use walkdir::WalkDir;
+
+use super::{RegexSearchError, RegexSearchMatch, line_range_for_match};
+
+#[derive(Debug, Clone)]
+pub struct RegexSearchEngine {
+    root: PathBuf,
+}
+
+impl RegexSearchEngine {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn search(&self, pattern: &str) -> Result<Vec<RegexSearchMatch>, RegexSearchError> {
+        let regex = Regex::new(pattern).map_err(RegexSearchError::InvalidPattern)?;
+        let mut matches = Vec::new();
+
+        for path in self.candidate_files() {
+            let Ok(content) = fs::read_to_string(&path) else {
+                continue;
+            };
+
+            matches.extend(verified_matches(&path, &content, &regex));
+        }
+
+        Ok(matches)
+    }
+
+    fn candidate_files(&self) -> Vec<PathBuf> {
+        let mut files = WalkDir::new(&self.root)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| entry.path().to_path_buf())
+            .collect::<Vec<_>>();
+
+        files.sort();
+        files
+    }
+}
+
+fn verified_matches(path: &Path, content: &str, regex: &Regex) -> Vec<RegexSearchMatch> {
+    regex
+        .find_iter(content)
+        .map(|match_| {
+            let byte_range = match_.start()..match_.end();
+            RegexSearchMatch {
+                path: path.to_path_buf(),
+                line_range: line_range_for_match(content, byte_range.clone()),
+                matched_text: match_.as_str().to_string(),
+                byte_range,
+            }
+        })
+        .collect()
+}

--- a/crates/core/src/regex_search/mod.rs
+++ b/crates/core/src/regex_search/mod.rs
@@ -1,84 +1,19 @@
-use std::{
-    fs,
-    ops::{Range, RangeInclusive},
-    path::{Path, PathBuf},
-};
-
-use regex::Regex;
-use walkdir::WalkDir;
-
+mod corpus;
+mod engine;
 mod trigram_index;
+mod types;
 
-pub use trigram_index::{Trigram, TrigramIndex};
+use std::ops::{Range, RangeInclusive};
 
-#[derive(Debug, thiserror::Error)]
-pub enum RegexSearchError {
-    #[error("invalid regex pattern")]
-    InvalidPattern(#[source] regex::Error),
-}
+pub use corpus::{CorpusDocument, FileSystemCorpus, RegexCorpus};
+pub use engine::RegexSearchEngine;
+pub use trigram_index::{TrigramIndex, trigrams};
+pub use types::{LiteralSearchResult, RegexSearchError, RegexSearchMatch, Trigram};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RegexSearchMatch {
-    pub path: PathBuf,
-    pub byte_range: Range<usize>,
-    pub line_range: RangeInclusive<usize>,
-    pub matched_text: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct RegexSearchEngine {
-    root: PathBuf,
-}
-
-impl RegexSearchEngine {
-    pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
-    }
-
-    pub fn search(&self, pattern: &str) -> Result<Vec<RegexSearchMatch>, RegexSearchError> {
-        let regex = Regex::new(pattern).map_err(RegexSearchError::InvalidPattern)?;
-        let mut matches = Vec::new();
-
-        for path in self.candidate_files() {
-            let Ok(content) = fs::read_to_string(&path) else {
-                continue;
-            };
-
-            matches.extend(verified_matches(&path, &content, &regex));
-        }
-
-        Ok(matches)
-    }
-
-    fn candidate_files(&self) -> Vec<PathBuf> {
-        let mut files = WalkDir::new(&self.root)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_type().is_file())
-            .map(|entry| entry.path().to_path_buf())
-            .collect::<Vec<_>>();
-
-        files.sort();
-        files
-    }
-}
-
-fn verified_matches(path: &Path, content: &str, regex: &Regex) -> Vec<RegexSearchMatch> {
-    regex
-        .find_iter(content)
-        .map(|match_| {
-            let byte_range = match_.start()..match_.end();
-            RegexSearchMatch {
-                path: path.to_path_buf(),
-                line_range: line_range_for_match(content, byte_range.clone()),
-                matched_text: match_.as_str().to_string(),
-                byte_range,
-            }
-        })
-        .collect()
-}
-
-fn line_range_for_match(content: &str, byte_range: Range<usize>) -> RangeInclusive<usize> {
+pub(crate) fn line_range_for_match(
+    content: &str,
+    byte_range: Range<usize>,
+) -> RangeInclusive<usize> {
     let start_line = line_number_at_byte(content, byte_range.start);
     let end_line = if byte_range.is_empty() {
         start_line
@@ -98,135 +33,4 @@ fn line_number_at_byte(content: &str, byte_index: usize) -> usize {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::path::Path;
-
-    use super::RegexSearchEngine;
-
-    #[test]
-    fn search_returns_path_byte_range_line_range_and_matched_text() {
-        let temp = tempfile::tempdir().unwrap();
-        let file = temp.path().join("src/lib.rs");
-        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
-        std::fs::write(&file, "alpha\nlet answer = 42;\nomega\n").unwrap();
-
-        let matches = RegexSearchEngine::new(temp.path())
-            .search(r"answer = \d+")
-            .unwrap();
-
-        assert_eq!(matches.len(), 1);
-        let match_ = &matches[0];
-        assert_eq!(match_.path, file);
-        assert_eq!(match_.byte_range, 10..21);
-        assert_eq!(match_.line_range, 2..=2);
-        assert_eq!(match_.matched_text, "answer = 42");
-    }
-
-    #[test]
-    fn search_returns_multiple_matches_in_file_order() {
-        let temp = tempfile::tempdir().unwrap();
-        let file = temp.path().join("lib.rs");
-        std::fs::write(&file, "todo one\ntodo two\ntodo three\n").unwrap();
-
-        let matches = RegexSearchEngine::new(temp.path())
-            .search(r"todo \w+")
-            .unwrap();
-
-        let matched_text = matches
-            .iter()
-            .map(|match_| match_.matched_text.as_str())
-            .collect::<Vec<_>>();
-        assert_eq!(matched_text, ["todo one", "todo two", "todo three"]);
-    }
-
-    #[test]
-    fn search_returns_files_in_deterministic_path_order() {
-        let temp = tempfile::tempdir().unwrap();
-        write_file(temp.path(), "zeta.rs", "needle z").unwrap();
-        write_file(temp.path(), "alpha.rs", "needle a").unwrap();
-        write_file(temp.path(), "nested/beta.rs", "needle b").unwrap();
-
-        let matches = RegexSearchEngine::new(temp.path())
-            .search(r"needle \w")
-            .unwrap();
-
-        let names = matches
-            .iter()
-            .map(|match_| {
-                match_
-                    .path
-                    .strip_prefix(temp.path())
-                    .unwrap()
-                    .to_string_lossy()
-                    .into_owned()
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(names, ["alpha.rs", "nested/beta.rs", "zeta.rs"]);
-    }
-
-    #[test]
-    fn search_returns_error_for_invalid_patterns() {
-        let temp = tempfile::tempdir().unwrap();
-
-        let error = RegexSearchEngine::new(temp.path()).search("(").unwrap_err();
-
-        assert!(error.to_string().contains("invalid regex pattern"));
-    }
-
-    #[test]
-    fn search_uses_regex_line_boundary_flags_explicitly() {
-        let temp = tempfile::tempdir().unwrap();
-        let file = temp.path().join("lib.rs");
-        std::fs::write(&file, "alpha\nbeta\ngamma\n").unwrap();
-
-        let matches = RegexSearchEngine::new(temp.path())
-            .search(r"(?m)^beta$")
-            .unwrap();
-
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, file);
-        assert_eq!(matches[0].byte_range, 6..10);
-        assert_eq!(matches[0].line_range, 2..=2);
-        assert_eq!(matches[0].matched_text, "beta");
-    }
-
-    #[test]
-    fn search_reports_multiline_match_line_ranges() {
-        let temp = tempfile::tempdir().unwrap();
-        let file = temp.path().join("lib.rs");
-        std::fs::write(&file, "alpha\nbeta\ngamma\n").unwrap();
-
-        let matches = RegexSearchEngine::new(temp.path())
-            .search(r"(?s)alpha.*gamma")
-            .unwrap();
-
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].path, file);
-        assert_eq!(matches[0].byte_range, 0..16);
-        assert_eq!(matches[0].line_range, 1..=3);
-        assert_eq!(matches[0].matched_text, "alpha\nbeta\ngamma");
-    }
-
-    #[test]
-    fn search_skips_non_utf8_files() {
-        let temp = tempfile::tempdir().unwrap();
-        std::fs::write(temp.path().join("binary.bin"), [0xff, 0xfe, b'n', b'e']).unwrap();
-        std::fs::write(temp.path().join("text.txt"), "needle").unwrap();
-
-        let matches = RegexSearchEngine::new(temp.path())
-            .search("needle")
-            .unwrap();
-
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].matched_text, "needle");
-        assert_eq!(matches[0].path, temp.path().join("text.txt"));
-    }
-
-    fn write_file(root: &Path, path: &str, content: &str) -> std::io::Result<()> {
-        let path = root.join(path);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(path, content)
-    }
-}
+mod tests;

--- a/crates/core/src/regex_search/tests.rs
+++ b/crates/core/src/regex_search/tests.rs
@@ -1,0 +1,308 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use super::{CorpusDocument, RegexCorpus, RegexSearchEngine, Trigram, TrigramIndex, trigrams};
+
+#[derive(Debug, Clone, Default)]
+struct TestCorpus {
+    documents: BTreeMap<PathBuf, String>,
+}
+
+impl TestCorpus {
+    fn new(documents: &[(&str, &str)]) -> Self {
+        Self {
+            documents: documents
+                .iter()
+                .map(|(path, content)| (PathBuf::from(path), (*content).to_string()))
+                .collect(),
+        }
+    }
+}
+
+impl RegexCorpus for TestCorpus {
+    fn documents(&self) -> Vec<CorpusDocument> {
+        self.documents
+            .iter()
+            .map(|(path, content)| CorpusDocument {
+                path: path.clone(),
+                content: content.clone(),
+            })
+            .collect()
+    }
+
+    fn read_document(&self, path: &Path) -> Option<String> {
+        self.documents.get(path).cloned()
+    }
+}
+
+#[test]
+fn search_returns_path_byte_range_line_range_and_matched_text() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("src/lib.rs");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, "alpha\nlet answer = 42;\nomega\n").unwrap();
+
+    let matches = RegexSearchEngine::new(temp.path())
+        .search(r"answer = \d+")
+        .unwrap();
+
+    assert_eq!(matches.len(), 1);
+    let match_ = &matches[0];
+    assert_eq!(match_.path, file);
+    assert_eq!(match_.byte_range, 10..21);
+    assert_eq!(match_.line_range, 2..=2);
+    assert_eq!(match_.matched_text, "answer = 42");
+}
+
+#[test]
+fn search_returns_multiple_matches_in_file_order() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("lib.rs");
+    std::fs::write(&file, "todo one\ntodo two\ntodo three\n").unwrap();
+
+    let matches = RegexSearchEngine::new(temp.path())
+        .search(r"todo \w+")
+        .unwrap();
+
+    let matched_text = matches
+        .iter()
+        .map(|match_| match_.matched_text.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(matched_text, ["todo one", "todo two", "todo three"]);
+}
+
+#[test]
+fn search_returns_files_in_deterministic_path_order() {
+    let temp = tempfile::tempdir().unwrap();
+    write_file(temp.path(), "zeta.rs", "needle z").unwrap();
+    write_file(temp.path(), "alpha.rs", "needle a").unwrap();
+    write_file(temp.path(), "nested/beta.rs", "needle b").unwrap();
+
+    let matches = RegexSearchEngine::new(temp.path())
+        .search(r"needle \w")
+        .unwrap();
+
+    let names = matches
+        .iter()
+        .map(|match_| {
+            match_
+                .path
+                .strip_prefix(temp.path())
+                .unwrap()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["alpha.rs", "nested/beta.rs", "zeta.rs"]);
+}
+
+#[test]
+fn search_returns_error_for_invalid_patterns() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let error = RegexSearchEngine::new(temp.path()).search("(").unwrap_err();
+
+    assert!(error.to_string().contains("invalid regex pattern"));
+}
+
+#[test]
+fn search_uses_regex_line_boundary_flags_explicitly() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("lib.rs");
+    std::fs::write(&file, "alpha\nbeta\ngamma\n").unwrap();
+
+    let matches = RegexSearchEngine::new(temp.path())
+        .search(r"(?m)^beta$")
+        .unwrap();
+
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].path, file);
+    assert_eq!(matches[0].byte_range, 6..10);
+    assert_eq!(matches[0].line_range, 2..=2);
+    assert_eq!(matches[0].matched_text, "beta");
+}
+
+#[test]
+fn search_reports_multiline_match_line_ranges() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("lib.rs");
+    std::fs::write(&file, "alpha\nbeta\ngamma\n").unwrap();
+
+    let matches = RegexSearchEngine::new(temp.path())
+        .search(r"(?s)alpha.*gamma")
+        .unwrap();
+
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].path, file);
+    assert_eq!(matches[0].byte_range, 0..16);
+    assert_eq!(matches[0].line_range, 1..=3);
+    assert_eq!(matches[0].matched_text, "alpha\nbeta\ngamma");
+}
+
+#[test]
+fn search_skips_non_utf8_files() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("binary.bin"), [0xff, 0xfe, b'n', b'e']).unwrap();
+    std::fs::write(temp.path().join("text.txt"), "needle").unwrap();
+
+    let matches = RegexSearchEngine::new(temp.path())
+        .search("needle")
+        .unwrap();
+
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].matched_text, "needle");
+    assert_eq!(matches[0].path, temp.path().join("text.txt"));
+}
+
+#[test]
+fn trigrams_are_overlapping_character_windows() {
+    let trigrams = trigrams("abcd");
+
+    let values = trigrams.iter().map(Trigram::as_str).collect::<Vec<_>>();
+    assert_eq!(values, ["abc", "bcd"]);
+}
+
+#[test]
+fn trigrams_return_empty_for_short_strings() {
+    assert!(trigrams("").is_empty());
+    assert!(trigrams("a").is_empty());
+    assert!(trigrams("ab").is_empty());
+}
+
+#[test]
+fn trigrams_include_punctuation_whitespace_and_preserve_case() {
+    let trigrams = trigrams("A b!");
+
+    let values = trigrams.iter().map(Trigram::as_str).collect::<Vec<_>>();
+    assert_eq!(values, ["A b", " b!"]);
+}
+
+#[test]
+fn index_maps_every_indexed_doc_id_back_to_path() {
+    let first = PathBuf::from("a.rs");
+    let second = PathBuf::from("b.rs");
+    let index =
+        TrigramIndex::with_corpus(TestCorpus::new(&[("a.rs", "abcdef"), ("b.rs", "uvwxyz")]));
+    let first_id = index.doc_id(&first).unwrap();
+    let second_id = index.doc_id(&second).unwrap();
+
+    assert_eq!(index.num_docs(), 2);
+    assert_eq!(index.document(first_id).unwrap().path, first);
+    assert_eq!(index.document(second_id).unwrap().path, second);
+}
+
+#[test]
+fn postings_record_documents_containing_each_trigram() {
+    let first = PathBuf::from("a.rs");
+    let second = PathBuf::from("b.rs");
+    let index =
+        TrigramIndex::with_corpus(TestCorpus::new(&[("a.rs", "abcdef"), ("b.rs", "zabczz")]));
+    let postings = index.postings(&Trigram::from("abc")).unwrap();
+
+    assert!(postings.contains(&index.doc_id(&first).unwrap()));
+    assert!(postings.contains(&index.doc_id(&second).unwrap()));
+}
+
+#[test]
+fn literal_candidates_are_supersets_of_true_matches() {
+    let matching = PathBuf::from("match.rs");
+    let false_positive = PathBuf::from("false_positive.rs");
+    let missing = PathBuf::from("missing.rs");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "xxabcdefxx"),
+        ("false_positive.rs", "abc bcd cde def"),
+        ("missing.rs", "abxde"),
+    ]));
+    let candidates = index.candidates_for_literal("abcdef");
+
+    assert!(candidates.contains(&index.doc_id(&matching).unwrap()));
+    assert!(candidates.contains(&index.doc_id(&false_positive).unwrap()));
+    assert!(!candidates.contains(&index.doc_id(&missing).unwrap()));
+}
+
+#[test]
+fn short_literal_candidates_include_all_indexed_documents() {
+    let first = PathBuf::from("a.rs");
+    let second = PathBuf::from("b.rs");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[("a.rs", "a"), ("b.rs", "b")]));
+    let candidates = index.candidates_for_literal("ab");
+
+    assert_eq!(candidates.len(), 2);
+    assert!(candidates.contains(&index.doc_id(&first).unwrap()));
+    assert!(candidates.contains(&index.doc_id(&second).unwrap()));
+}
+
+#[test]
+fn literal_search_verifies_candidates_and_reports_candidate_count() {
+    let matching = PathBuf::from("match.rs");
+    let result = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "xxabcdefxx"),
+        ("false_positive.rs", "abc bcd cde def"),
+        ("missing.rs", "unrelated"),
+    ]))
+    .search_literal("abcdef");
+
+    assert_eq!(result.candidate_count, 2);
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.matches[0].path, matching);
+    assert_eq!(result.matches[0].byte_range, 2..8);
+    assert_eq!(result.matches[0].line_range, 1..=1);
+    assert_eq!(result.matches[0].matched_text, "abcdef");
+}
+
+#[test]
+fn literal_search_matches_full_scan_results() {
+    let result = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("a.rs", "needle one\nneedle two\n"),
+        ("nested/b.rs", "no match here"),
+        ("z.rs", "needle three"),
+    ]))
+    .search_literal("needle");
+
+    let matched_paths = result
+        .matches
+        .iter()
+        .map(|match_| match_.path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(matched_paths, ["a.rs", "a.rs", "z.rs"]);
+    assert_eq!(result.matches[0].byte_range, 0..6);
+    assert_eq!(result.matches[1].byte_range, 11..17);
+    assert_eq!(result.matches[2].byte_range, 0..6);
+}
+
+#[test]
+fn short_literal_search_falls_back_to_all_documents() {
+    let first = PathBuf::from("a.rs");
+    let result = TrigramIndex::with_corpus(TestCorpus::new(&[("a.rs", "aba"), ("b.rs", "zzz")]))
+        .search_literal("ab");
+
+    assert_eq!(result.candidate_count, 2);
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.matches[0].path, first);
+    assert_eq!(result.matches[0].byte_range, 0..2);
+}
+
+#[test]
+fn selective_literal_search_uses_fewer_candidates_than_corpus() {
+    let matching = PathBuf::from("match.rs");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "rare_literal"),
+        ("a.rs", "common text"),
+        ("b.rs", "more text"),
+    ]));
+    let result = index.search_literal("rare_literal");
+
+    assert_eq!(index.num_docs(), 3);
+    assert_eq!(result.candidate_count, 1);
+    assert_eq!(result.matches[0].path, matching);
+}
+
+fn write_file(root: &Path, path: &str, content: &str) -> std::io::Result<()> {
+    let path = root.join(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, content)
+}

--- a/crates/core/src/regex_search/trigram_index.rs
+++ b/crates/core/src/regex_search/trigram_index.rs
@@ -1,66 +1,62 @@
 use std::{
     collections::{BTreeSet, HashMap},
-    fs,
-    path::{Path, PathBuf},
+    ops::Range,
+    path::Path,
 };
 
-use walkdir::WalkDir;
-
+use super::{
+    FileSystemCorpus, LiteralSearchResult, RegexCorpus, RegexSearchMatch, Trigram,
+    line_range_for_match,
+};
 use crate::index::{
     DocId,
     document_registry::{DocumentCatalog, DocumentMetadata, DocumentRegistry},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Trigram(String);
-
-impl Trigram {
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<&str> for Trigram {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
-    }
-}
-
 #[derive(Debug)]
-pub struct TrigramIndex {
+pub struct TrigramIndex<C = FileSystemCorpus> {
+    corpus: C,
     postings: HashMap<Trigram, BTreeSet<DocId>>,
     documents: DocumentRegistry,
     doc_ids_by_path: Vec<DocId>,
 }
 
-impl TrigramIndex {
+impl TrigramIndex<FileSystemCorpus> {
     pub fn new(root: impl AsRef<Path>) -> Self {
+        Self::with_corpus(FileSystemCorpus::new(root.as_ref()))
+    }
+}
+
+impl<C> TrigramIndex<C>
+where
+    C: RegexCorpus,
+{
+    pub fn with_corpus(corpus: C) -> Self {
         let mut documents = DocumentRegistry::new();
         let mut postings: HashMap<Trigram, BTreeSet<DocId>> = HashMap::new();
-        let mut indexed_files = candidate_files(root.as_ref());
+        let mut corpus_documents = corpus.documents();
+        corpus_documents.sort_by(|left, right| left.path.cmp(&right.path));
 
-        indexed_files.sort();
-
-        for path in &indexed_files {
-            let Ok(content) = fs::read_to_string(path) else {
-                continue;
-            };
-
+        for document in &corpus_documents {
             let doc_id = documents.insert_or_update(
-                path.to_path_buf(),
-                trigram_count(&content),
-                content.len() as u64,
+                document.path.clone(),
+                trigram_count(&document.content),
+                document.content.len() as u64,
             );
 
-            for trigram in trigrams(&content) {
+            for trigram in trigrams(&document.content) {
                 postings.entry(trigram).or_default().insert(doc_id);
             }
         }
 
-        let mut doc_ids_by_path = documents_by_path(&documents, &indexed_files);
+        let mut doc_ids_by_path = corpus_documents
+            .iter()
+            .filter_map(|document| documents.doc_id(&document.path))
+            .collect::<Vec<_>>();
         doc_ids_by_path.sort();
 
         Self {
+            corpus,
             postings,
             documents,
             doc_ids_by_path,
@@ -103,6 +99,37 @@ impl TrigramIndex {
 
         candidates
     }
+
+    pub fn search_literal(&self, literal: &str) -> LiteralSearchResult {
+        if literal.is_empty() {
+            return LiteralSearchResult {
+                candidate_count: 0,
+                matches: Vec::new(),
+            };
+        }
+
+        let candidate_ids = self.candidates_for_literal(literal);
+        let candidate_count = candidate_ids.len();
+        let mut candidate_paths = candidate_ids
+            .iter()
+            .filter_map(|&doc_id| self.document(doc_id).map(|document| document.path.clone()))
+            .collect::<Vec<_>>();
+        candidate_paths.sort();
+
+        let mut matches = Vec::new();
+        for path in candidate_paths {
+            let Some(content) = self.corpus.read_document(&path) else {
+                continue;
+            };
+
+            matches.extend(verified_literal_matches(&path, &content, literal));
+        }
+
+        LiteralSearchResult {
+            candidate_count,
+            matches,
+        }
+    }
 }
 
 pub fn trigrams(content: &str) -> Vec<Trigram> {
@@ -117,112 +144,20 @@ fn trigram_count(content: &str) -> usize {
     content.chars().count().saturating_sub(2)
 }
 
-fn candidate_files(root: &Path) -> Vec<PathBuf> {
-    WalkDir::new(root)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_type().is_file())
-        .map(|entry| entry.path().to_path_buf())
+fn verified_literal_matches(path: &Path, content: &str, literal: &str) -> Vec<RegexSearchMatch> {
+    content
+        .match_indices(literal)
+        .map(|(start, matched_text)| {
+            literal_match(path, content, start..start + matched_text.len())
+        })
         .collect()
 }
 
-fn documents_by_path(documents: &DocumentRegistry, paths: &[PathBuf]) -> Vec<DocId> {
-    paths
-        .iter()
-        .filter_map(|path| documents.doc_id(path))
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Trigram, TrigramIndex, trigrams};
-
-    #[test]
-    fn trigrams_are_overlapping_character_windows() {
-        let trigrams = trigrams("abcd");
-
-        let values = trigrams.iter().map(Trigram::as_str).collect::<Vec<_>>();
-        assert_eq!(values, ["abc", "bcd"]);
-    }
-
-    #[test]
-    fn trigrams_return_empty_for_short_strings() {
-        assert!(trigrams("").is_empty());
-        assert!(trigrams("a").is_empty());
-        assert!(trigrams("ab").is_empty());
-    }
-
-    #[test]
-    fn trigrams_include_punctuation_whitespace_and_preserve_case() {
-        let trigrams = trigrams("A b!");
-
-        let values = trigrams.iter().map(Trigram::as_str).collect::<Vec<_>>();
-        assert_eq!(values, ["A b", " b!"]);
-    }
-
-    #[test]
-    fn index_maps_every_indexed_doc_id_back_to_path() {
-        let temp = tempfile::tempdir().unwrap();
-        let first = temp.path().join("a.rs");
-        let second = temp.path().join("b.rs");
-        std::fs::write(&first, "abcdef").unwrap();
-        std::fs::write(&second, "uvwxyz").unwrap();
-
-        let index = TrigramIndex::new(temp.path());
-        let first_id = index.doc_id(&first).unwrap();
-        let second_id = index.doc_id(&second).unwrap();
-
-        assert_eq!(index.num_docs(), 2);
-        assert_eq!(index.document(first_id).unwrap().path, first);
-        assert_eq!(index.document(second_id).unwrap().path, second);
-    }
-
-    #[test]
-    fn postings_record_documents_containing_each_trigram() {
-        let temp = tempfile::tempdir().unwrap();
-        let first = temp.path().join("a.rs");
-        let second = temp.path().join("b.rs");
-        std::fs::write(&first, "abcdef").unwrap();
-        std::fs::write(&second, "zabczz").unwrap();
-
-        let index = TrigramIndex::new(temp.path());
-        let postings = index.postings(&Trigram::from("abc")).unwrap();
-
-        assert!(postings.contains(&index.doc_id(&first).unwrap()));
-        assert!(postings.contains(&index.doc_id(&second).unwrap()));
-    }
-
-    #[test]
-    fn literal_candidates_are_supersets_of_true_matches() {
-        let temp = tempfile::tempdir().unwrap();
-        let matching = temp.path().join("match.rs");
-        let false_positive = temp.path().join("false_positive.rs");
-        let missing = temp.path().join("missing.rs");
-        std::fs::write(&matching, "xxabcdefxx").unwrap();
-        std::fs::write(&false_positive, "abc bcd cde def").unwrap();
-        std::fs::write(&missing, "abxde").unwrap();
-
-        let index = TrigramIndex::new(temp.path());
-        let candidates = index.candidates_for_literal("abcdef");
-
-        assert!(candidates.contains(&index.doc_id(&matching).unwrap()));
-        assert!(candidates.contains(&index.doc_id(&false_positive).unwrap()));
-        assert!(!candidates.contains(&index.doc_id(&missing).unwrap()));
-    }
-
-    #[test]
-    fn short_literal_candidates_include_all_indexed_documents() {
-        let temp = tempfile::tempdir().unwrap();
-        let first = temp.path().join("a.rs");
-        let second = temp.path().join("b.rs");
-        std::fs::write(&first, "a").unwrap();
-        std::fs::write(&second, "b").unwrap();
-
-        let index = TrigramIndex::new(temp.path());
-        let candidates = index.candidates_for_literal("ab");
-
-        assert_eq!(candidates.len(), 2);
-        assert!(candidates.contains(&index.doc_id(&first).unwrap()));
-        assert!(candidates.contains(&index.doc_id(&second).unwrap()));
+fn literal_match(path: &Path, content: &str, byte_range: Range<usize>) -> RegexSearchMatch {
+    RegexSearchMatch {
+        path: path.to_path_buf(),
+        line_range: line_range_for_match(content, byte_range.clone()),
+        matched_text: content[byte_range.clone()].to_string(),
+        byte_range,
     }
 }

--- a/crates/core/src/regex_search/types.rs
+++ b/crates/core/src/regex_search/types.rs
@@ -1,0 +1,39 @@
+use std::{
+    ops::{Range, RangeInclusive},
+    path::PathBuf,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RegexSearchError {
+    #[error("invalid regex pattern")]
+    InvalidPattern(#[source] regex::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegexSearchMatch {
+    pub path: PathBuf,
+    pub byte_range: Range<usize>,
+    pub line_range: RangeInclusive<usize>,
+    pub matched_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Trigram(pub(crate) String);
+
+impl Trigram {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for Trigram {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiteralSearchResult {
+    pub candidate_count: usize,
+    pub matches: Vec<RegexSearchMatch>,
+}


### PR DESCRIPTION
- `regex_search` now follows the private-module plus parent re-export shape used by `evaluation::metrics`
- `RegexCorpus` separates corpus acquisition and document reads from the in-memory `TrigramIndex` postings implementation
- `TrigramIndex` can decompose literal strings into required trigrams, intersect postings, and report the candidate count
- literal search verifies candidate files with deterministic substring matching and returns the same span shape as regex search
- short literals fall back to all indexed documents while selective literals can use fewer candidates than the corpus