### PR TITLE
feat(regex): add regex trigram extraction

### DIFF
--- a/crates/core/src/regex_search/mod.rs
+++ b/crates/core/src/regex_search/mod.rs
@@ -1,5 +1,6 @@
 mod corpus;
 mod engine;
+mod regex_query;
 mod trigram_index;
 mod types;
 
@@ -7,6 +8,7 @@ use std::ops::{Range, RangeInclusive};
 
 pub use corpus::{CorpusDocument, FileSystemCorpus, RegexCorpus};
 pub use engine::RegexSearchEngine;
+pub use regex_query::RegexCandidatePlan;
 pub use trigram_index::{TrigramIndex, trigrams};
 pub use types::{LiteralSearchResult, RegexSearchError, RegexSearchMatch, Trigram};
 

--- a/crates/core/src/regex_search/regex_query.rs
+++ b/crates/core/src/regex_search/regex_query.rs
@@ -1,0 +1,279 @@
+use std::collections::BTreeSet;
+
+use super::{Trigram, trigrams};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegexCandidatePlan {
+    All,
+    And(Vec<Trigram>),
+    Or(Vec<RegexCandidatePlan>),
+}
+
+impl RegexCandidatePlan {
+    pub fn for_pattern(pattern: &str) -> Self {
+        if has_case_insensitive_flag(pattern) {
+            return Self::All;
+        }
+
+        let branches = split_top_level_alternation(pattern);
+        if branches.len() == 1 {
+            plan_for_concatenation(branches[0])
+        } else {
+            Self::Or(
+                branches
+                    .into_iter()
+                    .map(plan_for_concatenation)
+                    .collect::<Vec<_>>(),
+            )
+        }
+    }
+}
+
+fn plan_for_concatenation(pattern: &str) -> RegexCandidatePlan {
+    let mut analyzer = ConcatenationAnalyzer::default();
+    analyzer.analyze(pattern);
+    let trigrams = analyzer.required_trigrams();
+
+    if trigrams.is_empty() {
+        RegexCandidatePlan::All
+    } else {
+        RegexCandidatePlan::And(trigrams)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ConcatenationAnalyzer {
+    literals: Vec<String>,
+    current_literal: String,
+    last_atom_was_literal: bool,
+}
+
+impl ConcatenationAnalyzer {
+    fn analyze(&mut self, pattern: &str) {
+        let chars = pattern.chars().collect::<Vec<_>>();
+        let mut index = 0;
+        while index < chars.len() {
+            match chars[index] {
+                '\\' => {
+                    let Some((literal, next_index)) = escaped_literal(&chars, index) else {
+                        self.finish_literal();
+                        self.last_atom_was_literal = false;
+                        index += 2;
+                        continue;
+                    };
+                    self.current_literal.push(literal);
+                    self.last_atom_was_literal = true;
+                    index = next_index;
+                }
+                '[' => {
+                    let (literal, next_index) = character_class_literal(&chars, index);
+                    if let Some(literal) = literal {
+                        self.current_literal.push(literal);
+                        self.last_atom_was_literal = true;
+                    } else {
+                        self.finish_literal();
+                        self.last_atom_was_literal = false;
+                    }
+                    index = next_index;
+                }
+                '(' => {
+                    self.finish_literal();
+                    self.last_atom_was_literal = false;
+                    index = skip_group(&chars, index);
+                }
+                '.' | '^' | '$' => {
+                    self.finish_literal();
+                    self.last_atom_was_literal = false;
+                    index += 1;
+                }
+                '*' | '+' | '?' => {
+                    if self.last_atom_was_literal {
+                        self.remove_last_literal_char();
+                    }
+                    self.last_atom_was_literal = false;
+                    index += 1;
+                }
+                '{' => {
+                    if self.last_atom_was_literal {
+                        self.remove_last_literal_char();
+                    }
+                    self.last_atom_was_literal = false;
+                    index = skip_counted_repetition(&chars, index);
+                }
+                ')' | ']' => {
+                    self.finish_literal();
+                    self.last_atom_was_literal = false;
+                    index += 1;
+                }
+                literal => {
+                    self.current_literal.push(literal);
+                    self.last_atom_was_literal = true;
+                    index += 1;
+                }
+            }
+        }
+
+        self.finish_literal();
+    }
+
+    fn required_trigrams(&self) -> Vec<Trigram> {
+        let mut seen = BTreeSet::new();
+        for literal in &self.literals {
+            seen.extend(trigrams(literal));
+        }
+        seen.into_iter().collect()
+    }
+
+    fn finish_literal(&mut self) {
+        if !self.current_literal.is_empty() {
+            self.literals
+                .push(std::mem::take(&mut self.current_literal));
+        }
+    }
+
+    fn remove_last_literal_char(&mut self) {
+        self.current_literal.pop();
+        if self.current_literal.is_empty() {
+            self.literals.pop();
+        }
+    }
+}
+
+fn has_case_insensitive_flag(pattern: &str) -> bool {
+    pattern.contains("(?i") || pattern.contains("(?-i")
+}
+
+fn split_top_level_alternation(pattern: &str) -> Vec<&str> {
+    let chars = pattern.char_indices().collect::<Vec<_>>();
+    let mut branches = Vec::new();
+    let mut branch_start = 0;
+    let mut class_depth = 0;
+    let mut group_depth = 0;
+    let mut index = 0;
+
+    while index < chars.len() {
+        let (byte_index, char_) = chars[index];
+        match char_ {
+            '\\' => index += 2,
+            '[' if group_depth == 0 => {
+                class_depth += 1;
+                index += 1;
+            }
+            ']' if group_depth == 0 && class_depth > 0 => {
+                class_depth -= 1;
+                index += 1;
+            }
+            '(' if class_depth == 0 => {
+                group_depth += 1;
+                index += 1;
+            }
+            ')' if class_depth == 0 && group_depth > 0 => {
+                group_depth -= 1;
+                index += 1;
+            }
+            '|' if class_depth == 0 && group_depth == 0 => {
+                branches.push(&pattern[branch_start..byte_index]);
+                branch_start = byte_index + char_.len_utf8();
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    branches.push(&pattern[branch_start..]);
+    branches
+}
+
+fn escaped_literal(chars: &[char], index: usize) -> Option<(char, usize)> {
+    let escaped = *chars.get(index + 1)?;
+    match escaped {
+        'n' | 'r' | 't' | 'd' | 'D' | 's' | 'S' | 'w' | 'W' | 'b' | 'B' | 'A' | 'z' | 'Z' | 'p'
+        | 'P' | 'x' | 'u' => None,
+        literal => Some((literal, index + 2)),
+    }
+}
+
+fn character_class_literal(chars: &[char], start: usize) -> (Option<char>, usize) {
+    let mut index = start + 1;
+    let mut class_chars = Vec::new();
+    let mut negated = false;
+
+    if chars.get(index) == Some(&'^') {
+        negated = true;
+        index += 1;
+    }
+
+    while index < chars.len() {
+        match chars[index] {
+            '\\' => {
+                let Some((literal, next_index)) = escaped_literal(chars, index) else {
+                    return (None, skip_character_class(chars, start));
+                };
+                class_chars.push(literal);
+                index = next_index;
+            }
+            ']' => {
+                if !negated && class_chars.len() == 1 {
+                    return (class_chars.first().copied(), index + 1);
+                }
+                return (None, index + 1);
+            }
+            '-' => return (None, skip_character_class(chars, start)),
+            literal => {
+                class_chars.push(literal);
+                index += 1;
+            }
+        }
+    }
+
+    (None, chars.len())
+}
+
+fn skip_character_class(chars: &[char], start: usize) -> usize {
+    let mut index = start + 1;
+    while index < chars.len() {
+        match chars[index] {
+            '\\' => index += 2,
+            ']' => return index + 1,
+            _ => index += 1,
+        }
+    }
+    chars.len()
+}
+
+fn skip_group(chars: &[char], start: usize) -> usize {
+    let mut index = start + 1;
+    let mut depth = 1;
+
+    while index < chars.len() {
+        match chars[index] {
+            '\\' => index += 2,
+            '[' => index = skip_character_class(chars, index),
+            '(' => {
+                depth += 1;
+                index += 1;
+            }
+            ')' => {
+                depth -= 1;
+                index += 1;
+                if depth == 0 {
+                    return index;
+                }
+            }
+            _ => index += 1,
+        }
+    }
+
+    chars.len()
+}
+
+fn skip_counted_repetition(chars: &[char], start: usize) -> usize {
+    let mut index = start + 1;
+    while index < chars.len() {
+        if chars[index] == '}' {
+            return index + 1;
+        }
+        index += 1;
+    }
+    chars.len()
+}

--- a/crates/core/src/regex_search/tests.rs
+++ b/crates/core/src/regex_search/tests.rs
@@ -3,7 +3,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use super::{CorpusDocument, RegexCorpus, RegexSearchEngine, Trigram, TrigramIndex, trigrams};
+use regex::Regex;
+
+use super::{
+    CorpusDocument, RegexCandidatePlan, RegexCorpus, RegexSearchEngine, Trigram, TrigramIndex,
+    trigrams,
+};
 
 #[derive(Debug, Clone, Default)]
 struct TestCorpus {
@@ -299,10 +304,107 @@ fn selective_literal_search_uses_fewer_candidates_than_corpus() {
     assert_eq!(result.matches[0].path, matching);
 }
 
+#[test]
+fn regex_literal_pattern_decomposes_to_required_trigrams() {
+    let trigrams = plan_trigrams(&RegexCandidatePlan::for_pattern("abcdef"));
+
+    assert_eq!(trigrams, ["abc", "bcd", "cde", "def"]);
+}
+
+#[test]
+fn regex_concatenated_literals_preserve_required_trigrams() {
+    let trigrams = plan_trigrams(&RegexCandidatePlan::for_pattern(r"abc\.def"));
+
+    assert_eq!(trigrams, [".de", "abc", "bc.", "c.d", "def"]);
+}
+
+#[test]
+fn regex_alternation_produces_or_candidate_plan() {
+    let plan = RegexCandidatePlan::for_pattern("abcdef|uvwxyz");
+
+    let RegexCandidatePlan::Or(branches) = plan else {
+        panic!("expected alternation to produce an OR plan");
+    };
+
+    assert_eq!(branches.len(), 2);
+    assert_eq!(plan_trigrams(&branches[0]), ["abc", "bcd", "cde", "def"]);
+    assert_eq!(plan_trigrams(&branches[1]), ["uvw", "vwx", "wxy", "xyz"]);
+}
+
+#[test]
+fn regex_wildcards_drop_only_unsafe_local_fragment() {
+    let trigrams = plan_trigrams(&RegexCandidatePlan::for_pattern("abcdef.*uvwxyz"));
+
+    assert_eq!(
+        trigrams,
+        ["abc", "bcd", "cde", "def", "uvw", "vwx", "wxy", "xyz"]
+    );
+}
+
+#[test]
+fn regex_case_insensitive_pattern_falls_back_to_all_candidates() {
+    let plan = RegexCandidatePlan::for_pattern("(?i)abcdef");
+
+    assert_eq!(plan, RegexCandidatePlan::All);
+}
+
+#[test]
+fn regex_character_classes_are_conservative() {
+    let singleton = plan_trigrams(&RegexCandidatePlan::for_pattern("ab[c]def"));
+    let broad = plan_trigrams(&RegexCandidatePlan::for_pattern("abc[xyz]def"));
+
+    assert_eq!(singleton, ["abc", "bcd", "cde", "def"]);
+    assert_eq!(broad, ["abc", "def"]);
+}
+
+#[test]
+fn regex_candidate_generation_is_superset_of_verified_matches() {
+    let documents = [
+        ("match_abc.rs", "xxabcdefyy"),
+        ("match_uv.rs", "prefix uvwxyzz suffix"),
+        ("false_positive.rs", "abc bcd cde def"),
+        ("missing.rs", "nothing relevant"),
+    ];
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&documents));
+    let pattern = r"abcdef|uvwxyz";
+    let regex = Regex::new(pattern).unwrap();
+    let candidates = index.candidates_for_regex(pattern);
+
+    for (path, content) in documents {
+        let path = Path::new(path);
+        let doc_id = index.doc_id(path).unwrap();
+        if regex.is_match(content) {
+            assert!(candidates.contains(&doc_id));
+        }
+    }
+}
+
+#[test]
+fn unsupported_regex_constructs_fall_back_to_broader_candidates() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "foo123bar"),
+        ("other.rs", "unrelated"),
+    ]));
+    let candidates = index.candidates_for_regex(r"foo\d+bar");
+
+    assert!(candidates.contains(&index.doc_id(Path::new("match.rs")).unwrap()));
+}
+
 fn write_file(root: &Path, path: &str, content: &str) -> std::io::Result<()> {
     let path = root.join(path);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, content)
+}
+
+fn plan_trigrams(plan: &RegexCandidatePlan) -> Vec<String> {
+    let RegexCandidatePlan::And(trigrams) = plan else {
+        panic!("expected an AND plan");
+    };
+
+    trigrams
+        .iter()
+        .map(|trigram| trigram.as_str().to_string())
+        .collect()
 }

--- a/crates/core/src/regex_search/trigram_index.rs
+++ b/crates/core/src/regex_search/trigram_index.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use super::{
-    FileSystemCorpus, LiteralSearchResult, RegexCorpus, RegexSearchMatch, Trigram,
-    line_range_for_match,
+    FileSystemCorpus, LiteralSearchResult, RegexCandidatePlan, RegexCorpus, RegexSearchMatch,
+    Trigram, line_range_for_match,
 };
 use crate::index::{
     DocId,
@@ -81,23 +81,22 @@ where
 
     pub fn candidates_for_literal(&self, literal: &str) -> BTreeSet<DocId> {
         let query_trigrams = trigrams(literal);
-        if query_trigrams.is_empty() {
-            return self.doc_ids_by_path.iter().copied().collect();
+        self.candidates_for_trigrams(&query_trigrams)
+    }
+
+    pub fn candidates_for_regex(&self, pattern: &str) -> BTreeSet<DocId> {
+        self.candidates_for_regex_plan(&RegexCandidatePlan::for_pattern(pattern))
+    }
+
+    pub fn candidates_for_regex_plan(&self, plan: &RegexCandidatePlan) -> BTreeSet<DocId> {
+        match plan {
+            RegexCandidatePlan::All => self.doc_ids_by_path.iter().copied().collect(),
+            RegexCandidatePlan::And(trigrams) => self.candidates_for_trigrams(trigrams),
+            RegexCandidatePlan::Or(branches) => branches
+                .iter()
+                .flat_map(|branch| self.candidates_for_regex_plan(branch))
+                .collect(),
         }
-
-        let mut candidates = match self.postings(&query_trigrams[0]) {
-            Some(postings) => postings.clone(),
-            None => return BTreeSet::new(),
-        };
-
-        for trigram in &query_trigrams[1..] {
-            let Some(postings) = self.postings(trigram) else {
-                return BTreeSet::new();
-            };
-            candidates = candidates.intersection(postings).copied().collect();
-        }
-
-        candidates
     }
 
     pub fn search_literal(&self, literal: &str) -> LiteralSearchResult {
@@ -129,6 +128,26 @@ where
             candidate_count,
             matches,
         }
+    }
+
+    fn candidates_for_trigrams(&self, trigrams: &[Trigram]) -> BTreeSet<DocId> {
+        if trigrams.is_empty() {
+            return self.doc_ids_by_path.iter().copied().collect();
+        }
+
+        let mut candidates = match self.postings(&trigrams[0]) {
+            Some(postings) => postings.clone(),
+            None => return BTreeSet::new(),
+        };
+
+        for trigram in &trigrams[1..] {
+            let Some(postings) = self.postings(trigram) else {
+                return BTreeSet::new();
+            };
+            candidates = candidates.intersection(postings).copied().collect();
+        }
+
+        candidates
     }
 }
 


### PR DESCRIPTION
- add `RegexCandidatePlan` for conservative regex candidate decomposition into `all`, `and`, and `or` plans
- extract required trigrams from literal regex fragments while degrading broad wildcards, classes, groups, and unsupported escapes to broader candidates
- evaluate regex candidate plans through `TrigramIndex` using posting-list intersection for `and` and union for `or`
- cover literal, concatenation, alternation, wildcard, case-insensitive, character-class, and superset candidate behavior in `regex_search` tests