### PR TITLE
feat(regex): add regex candidate planner

### DIFF
--- a/crates/core/src/regex_search/mod.rs
+++ b/crates/core/src/regex_search/mod.rs
@@ -1,5 +1,6 @@
 mod corpus;
 mod engine;
+mod planner;
 mod regex_query;
 mod trigram_index;
 mod types;
@@ -10,7 +11,10 @@ pub use corpus::{CorpusDocument, FileSystemCorpus, RegexCorpus};
 pub use engine::RegexSearchEngine;
 pub use regex_query::RegexCandidatePlan;
 pub use trigram_index::{TrigramIndex, trigrams};
-pub use types::{LiteralSearchResult, RegexSearchError, RegexSearchMatch, Trigram};
+pub use types::{
+    LiteralSearchResult, RegexCandidateDiagnostics, RegexCandidateSelection, RegexSearchError,
+    RegexSearchMatch, Trigram,
+};
 
 pub(crate) fn line_range_for_match(
     content: &str,

--- a/crates/core/src/regex_search/planner.rs
+++ b/crates/core/src/regex_search/planner.rs
@@ -1,0 +1,135 @@
+use std::collections::{BTreeSet, HashMap};
+
+use super::{RegexCandidateDiagnostics, RegexCandidatePlan, RegexCandidateSelection, Trigram};
+use crate::index::DocId;
+
+const MAX_SELECTED_TRIGRAMS: usize = 8;
+
+pub(crate) fn plan_candidates(
+    plan: &RegexCandidatePlan,
+    postings: &HashMap<Trigram, BTreeSet<DocId>>,
+    all_doc_ids: &[DocId],
+) -> RegexCandidateSelection {
+    match plan {
+        RegexCandidatePlan::All => all_candidates(all_doc_ids),
+        RegexCandidatePlan::And(trigrams) => plan_conjunction(trigrams, postings, all_doc_ids),
+        RegexCandidatePlan::Or(branches) => plan_disjunction(branches, postings, all_doc_ids),
+    }
+}
+
+fn all_candidates(all_doc_ids: &[DocId]) -> RegexCandidateSelection {
+    let candidates = all_doc_ids.iter().copied().collect::<BTreeSet<_>>();
+    selection(candidates, all_doc_ids.len(), Vec::new(), true)
+}
+
+fn plan_disjunction(
+    branches: &[RegexCandidatePlan],
+    postings: &HashMap<Trigram, BTreeSet<DocId>>,
+    all_doc_ids: &[DocId],
+) -> RegexCandidateSelection {
+    let mut candidates = BTreeSet::new();
+    let mut selected_trigrams = Vec::new();
+    let mut fell_back_to_full_scan = false;
+
+    for branch in branches {
+        let branch_selection = plan_candidates(branch, postings, all_doc_ids);
+        candidates.extend(branch_selection.candidates);
+        selected_trigrams.extend(branch_selection.diagnostics.selected_trigrams);
+        fell_back_to_full_scan |= branch_selection.diagnostics.fell_back_to_full_scan;
+    }
+
+    selection(
+        candidates,
+        all_doc_ids.len(),
+        selected_trigrams,
+        fell_back_to_full_scan,
+    )
+}
+
+fn plan_conjunction(
+    trigrams: &[Trigram],
+    postings: &HashMap<Trigram, BTreeSet<DocId>>,
+    all_doc_ids: &[DocId],
+) -> RegexCandidateSelection {
+    if trigrams.is_empty() {
+        return all_candidates(all_doc_ids);
+    }
+
+    let mut posting_sizes = Vec::with_capacity(trigrams.len());
+    for trigram in trigrams {
+        let Some(posting) = postings.get(trigram) else {
+            return selection(
+                BTreeSet::new(),
+                all_doc_ids.len(),
+                vec![trigram.clone()],
+                false,
+            );
+        };
+        posting_sizes.push((trigram, posting.len()));
+    }
+
+    posting_sizes.sort_by(|(left_trigram, left_len), (right_trigram, right_len)| {
+        left_len
+            .cmp(right_len)
+            .then_with(|| left_trigram.cmp(right_trigram))
+    });
+
+    let mut estimated_work = 0;
+    let mut selected_trigrams = Vec::new();
+    for (trigram, posting_len) in posting_sizes {
+        if selected_trigrams.len() >= MAX_SELECTED_TRIGRAMS {
+            break;
+        }
+        if estimated_work + posting_len >= all_doc_ids.len() {
+            break;
+        }
+
+        estimated_work += posting_len;
+        selected_trigrams.push(trigram.clone());
+    }
+
+    if selected_trigrams.is_empty() {
+        return all_candidates(all_doc_ids);
+    }
+
+    let candidates = intersect_postings(&selected_trigrams, postings);
+    selection(candidates, all_doc_ids.len(), selected_trigrams, false)
+}
+
+fn intersect_postings(
+    trigrams: &[Trigram],
+    postings: &HashMap<Trigram, BTreeSet<DocId>>,
+) -> BTreeSet<DocId> {
+    let Some((first, rest)) = trigrams.split_first() else {
+        return BTreeSet::new();
+    };
+
+    let mut candidates = postings.get(first).cloned().unwrap_or_else(BTreeSet::new);
+
+    for trigram in rest {
+        let Some(posting) = postings.get(trigram) else {
+            return BTreeSet::new();
+        };
+        candidates = candidates.intersection(posting).copied().collect();
+    }
+
+    candidates
+}
+
+fn selection(
+    candidates: BTreeSet<DocId>,
+    full_corpus_count: usize,
+    selected_trigrams: Vec<Trigram>,
+    fell_back_to_full_scan: bool,
+) -> RegexCandidateSelection {
+    RegexCandidateSelection {
+        diagnostics: RegexCandidateDiagnostics {
+            full_corpus_count,
+            candidate_count: candidates.len(),
+            selected_trigram_count: selected_trigrams.len(),
+            selected_trigrams,
+            fell_back_to_full_scan,
+        },
+        candidates,
+    }
+}

--- a/crates/core/src/regex_search/tests.rs
+++ b/crates/core/src/regex_search/tests.rs
@@ -380,6 +380,107 @@ fn regex_candidate_generation_is_superset_of_verified_matches() {
 }
 
 #[test]
+fn regex_planner_selects_rare_trigram_before_common_trigram() {
+    let selected = Trigram::from("xyz");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "abc---xyz"),
+        ("common_a.rs", "abc---aaa"),
+        ("common_b.rs", "abc---bbb"),
+    ]));
+    let plan = RegexCandidatePlan::And(vec![Trigram::from("abc"), selected.clone()]);
+
+    let selection = index.planned_candidates_for_regex_plan(&plan);
+
+    assert_eq!(selection.diagnostics.selected_trigrams, [selected]);
+    assert_eq!(selection.diagnostics.candidate_count, 1);
+    assert!(
+        selection
+            .candidates
+            .contains(&index.doc_id(Path::new("match.rs")).unwrap())
+    );
+}
+
+#[test]
+fn regex_planner_missing_trigram_yields_no_candidates() {
+    let index =
+        TrigramIndex::with_corpus(TestCorpus::new(&[("a.rs", "abcdef"), ("b.rs", "uvwxyz")]));
+    let plan = RegexCandidatePlan::And(vec![Trigram::from("zzz")]);
+
+    let selection = index.planned_candidates_for_regex_plan(&plan);
+
+    assert!(selection.candidates.is_empty());
+    assert_eq!(selection.diagnostics.candidate_count, 0);
+    assert!(!selection.diagnostics.fell_back_to_full_scan);
+}
+
+#[test]
+fn regex_planner_common_pattern_falls_back_to_full_scan() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("a.rs", "abc one"),
+        ("b.rs", "abc two"),
+        ("c.rs", "abc three"),
+    ]));
+    let plan = RegexCandidatePlan::And(vec![Trigram::from("abc")]);
+
+    let selection = index.planned_candidates_for_regex_plan(&plan);
+
+    assert_eq!(selection.diagnostics.full_corpus_count, 3);
+    assert_eq!(selection.diagnostics.candidate_count, 3);
+    assert_eq!(selection.diagnostics.selected_trigram_count, 0);
+    assert!(selection.diagnostics.fell_back_to_full_scan);
+}
+
+#[test]
+fn regex_planner_plans_alternation_branches_independently() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("first.rs", "abc---xyz"),
+        ("second.rs", "def---uvw"),
+        ("common_a.rs", "abc---def"),
+        ("common_b.rs", "abc---def"),
+    ]));
+    let plan = RegexCandidatePlan::Or(vec![
+        RegexCandidatePlan::And(vec![Trigram::from("abc"), Trigram::from("xyz")]),
+        RegexCandidatePlan::And(vec![Trigram::from("def"), Trigram::from("uvw")]),
+    ]);
+
+    let selection = index.planned_candidates_for_regex_plan(&plan);
+    let selected = selection
+        .diagnostics
+        .selected_trigrams
+        .iter()
+        .map(Trigram::as_str)
+        .collect::<Vec<_>>();
+
+    assert_eq!(selected, ["xyz", "uvw"]);
+    assert_eq!(selection.diagnostics.candidate_count, 2);
+    assert!(
+        selection
+            .candidates
+            .contains(&index.doc_id(Path::new("first.rs")).unwrap())
+    );
+    assert!(
+        selection
+            .candidates
+            .contains(&index.doc_id(Path::new("second.rs")).unwrap())
+    );
+}
+
+#[test]
+fn regex_planner_selective_pattern_uses_fewer_candidates_than_corpus() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "rare_literal"),
+        ("a.rs", "common text"),
+        ("b.rs", "more text"),
+    ]));
+
+    let selection = index.planned_candidates_for_regex("rare_literal");
+
+    assert_eq!(selection.diagnostics.full_corpus_count, 3);
+    assert_eq!(selection.diagnostics.candidate_count, 1);
+    assert!(selection.diagnostics.candidate_count < index.num_docs());
+}
+
+#[test]
 fn unsupported_regex_constructs_fall_back_to_broader_candidates() {
     let index = TrigramIndex::with_corpus(TestCorpus::new(&[
         ("match.rs", "foo123bar"),

--- a/crates/core/src/regex_search/trigram_index.rs
+++ b/crates/core/src/regex_search/trigram_index.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use super::{
-    FileSystemCorpus, LiteralSearchResult, RegexCandidatePlan, RegexCorpus, RegexSearchMatch,
-    Trigram, line_range_for_match,
+    FileSystemCorpus, LiteralSearchResult, RegexCandidatePlan, RegexCandidateSelection,
+    RegexCorpus, RegexSearchMatch, Trigram, line_range_for_match, planner,
 };
 use crate::index::{
     DocId,
@@ -81,7 +81,8 @@ where
 
     pub fn candidates_for_literal(&self, literal: &str) -> BTreeSet<DocId> {
         let query_trigrams = trigrams(literal);
-        self.candidates_for_trigrams(&query_trigrams)
+        self.planned_candidates_for_regex_plan(&RegexCandidatePlan::And(query_trigrams))
+            .candidates
     }
 
     pub fn candidates_for_regex(&self, pattern: &str) -> BTreeSet<DocId> {
@@ -89,14 +90,18 @@ where
     }
 
     pub fn candidates_for_regex_plan(&self, plan: &RegexCandidatePlan) -> BTreeSet<DocId> {
-        match plan {
-            RegexCandidatePlan::All => self.doc_ids_by_path.iter().copied().collect(),
-            RegexCandidatePlan::And(trigrams) => self.candidates_for_trigrams(trigrams),
-            RegexCandidatePlan::Or(branches) => branches
-                .iter()
-                .flat_map(|branch| self.candidates_for_regex_plan(branch))
-                .collect(),
-        }
+        self.planned_candidates_for_regex_plan(plan).candidates
+    }
+
+    pub fn planned_candidates_for_regex(&self, pattern: &str) -> RegexCandidateSelection {
+        self.planned_candidates_for_regex_plan(&RegexCandidatePlan::for_pattern(pattern))
+    }
+
+    pub fn planned_candidates_for_regex_plan(
+        &self,
+        plan: &RegexCandidatePlan,
+    ) -> RegexCandidateSelection {
+        planner::plan_candidates(plan, &self.postings, &self.doc_ids_by_path)
     }
 
     pub fn search_literal(&self, literal: &str) -> LiteralSearchResult {
@@ -128,26 +133,6 @@ where
             candidate_count,
             matches,
         }
-    }
-
-    fn candidates_for_trigrams(&self, trigrams: &[Trigram]) -> BTreeSet<DocId> {
-        if trigrams.is_empty() {
-            return self.doc_ids_by_path.iter().copied().collect();
-        }
-
-        let mut candidates = match self.postings(&trigrams[0]) {
-            Some(postings) => postings.clone(),
-            None => return BTreeSet::new(),
-        };
-
-        for trigram in &trigrams[1..] {
-            let Some(postings) = self.postings(trigram) else {
-                return BTreeSet::new();
-            };
-            candidates = candidates.intersection(postings).copied().collect();
-        }
-
-        candidates
     }
 }
 

--- a/crates/core/src/regex_search/types.rs
+++ b/crates/core/src/regex_search/types.rs
@@ -1,7 +1,10 @@
 use std::{
+    collections::BTreeSet,
     ops::{Range, RangeInclusive},
     path::PathBuf,
 };
+
+use crate::index::DocId;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RegexSearchError {
@@ -36,4 +39,19 @@ impl From<&str> for Trigram {
 pub struct LiteralSearchResult {
     pub candidate_count: usize,
     pub matches: Vec<RegexSearchMatch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegexCandidateSelection {
+    pub candidates: BTreeSet<DocId>,
+    pub diagnostics: RegexCandidateDiagnostics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegexCandidateDiagnostics {
+    pub full_corpus_count: usize,
+    pub candidate_count: usize,
+    pub selected_trigram_count: usize,
+    pub selected_trigrams: Vec<Trigram>,
+    pub fell_back_to_full_scan: bool,
 }


### PR DESCRIPTION
- add a private `regex_search` planner that estimates posting-list work before candidate generation
- order `RegexCandidatePlan::And` constraints by posting-list selectivity and cap selected trigram complexity
- fall back to full-corpus candidates when selected postings would be no better than scanning
- expose structured `RegexCandidateDiagnostics` for candidate count, selected trigrams, corpus size, and fallback state
- keep `RegexCandidatePlan::Or` branch planning independent before unioning candidates