### PR TITLE
feat(regex): add regex index freshness updates

### DIFF
--- a/crates/core/src/regex_search/tests.rs
+++ b/crates/core/src/regex_search/tests.rs
@@ -481,6 +481,53 @@ fn regex_planner_selective_pattern_uses_fewer_candidates_than_corpus() {
 }
 
 #[test]
+fn refreshing_document_adds_new_file_without_full_reindex() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut index = TrigramIndex::new(temp.path());
+    let file = temp.path().join("new.rs");
+    std::fs::write(&file, "fresh_needle").unwrap();
+
+    index.refresh_document(&file);
+    let result = index.search_literal("fresh_needle");
+
+    assert_eq!(index.num_docs(), 1);
+    assert_eq!(result.candidate_count, 1);
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.matches[0].path, file);
+}
+
+#[test]
+fn refreshing_document_removes_stale_postings_for_modified_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("lib.rs");
+    std::fs::write(&file, "old_needle").unwrap();
+    let mut index = TrigramIndex::new(temp.path());
+    std::fs::write(&file, "new_needle").unwrap();
+
+    index.refresh_document(&file);
+
+    assert!(index.search_literal("old_needle").matches.is_empty());
+    assert_eq!(index.search_literal("new_needle").matches.len(), 1);
+}
+
+#[test]
+fn removing_document_prevents_deleted_file_from_leaking_candidates() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("lib.rs");
+    std::fs::write(&file, "deleted_needle").unwrap();
+    let mut index = TrigramIndex::new(temp.path());
+    std::fs::remove_file(&file).unwrap();
+
+    let removed = index.remove_document(&file);
+    let result = index.search_literal("deleted_needle");
+
+    assert!(removed);
+    assert_eq!(index.num_docs(), 0);
+    assert_eq!(result.candidate_count, 0);
+    assert!(result.matches.is_empty());
+}
+
+#[test]
 fn unsupported_regex_constructs_fall_back_to_broader_candidates() {
     let index = TrigramIndex::with_corpus(TestCorpus::new(&[
         ("match.rs", "foo123bar"),

--- a/crates/core/src/regex_search/trigram_index.rs
+++ b/crates/core/src/regex_search/trigram_index.rs
@@ -38,22 +38,15 @@ where
         corpus_documents.sort_by(|left, right| left.path.cmp(&right.path));
 
         for document in &corpus_documents {
-            let doc_id = documents.insert_or_update(
+            insert_document(
+                &mut documents,
+                &mut postings,
                 document.path.clone(),
-                trigram_count(&document.content),
-                document.content.len() as u64,
+                &document.content,
             );
-
-            for trigram in trigrams(&document.content) {
-                postings.entry(trigram).or_default().insert(doc_id);
-            }
         }
 
-        let mut doc_ids_by_path = corpus_documents
-            .iter()
-            .filter_map(|document| documents.doc_id(&document.path))
-            .collect::<Vec<_>>();
-        doc_ids_by_path.sort();
+        let doc_ids_by_path = sorted_doc_ids(&corpus_documents, &documents);
 
         Self {
             corpus,
@@ -77,6 +70,45 @@ where
 
     pub fn num_docs(&self) -> usize {
         self.documents.len()
+    }
+
+    pub fn refresh_document(&mut self, path: impl AsRef<Path>) {
+        let path = path.as_ref();
+        if let Some(doc_id) = self.remove_document_from_postings(path) {
+            self.doc_ids_by_path
+                .retain(|indexed_id| *indexed_id != doc_id);
+        }
+
+        if let Some(content) = self.corpus.read_document(path) {
+            let doc_id = insert_document(
+                &mut self.documents,
+                &mut self.postings,
+                path.to_path_buf(),
+                &content,
+            );
+            self.doc_ids_by_path.push(doc_id);
+            self.doc_ids_by_path.sort();
+        }
+    }
+
+    pub fn remove_document(&mut self, path: impl AsRef<Path>) -> bool {
+        let Some(doc_id) = self.remove_document_from_postings(path.as_ref()) else {
+            return false;
+        };
+
+        self.doc_ids_by_path
+            .retain(|indexed_id| *indexed_id != doc_id);
+        true
+    }
+
+    fn remove_document_from_postings(&mut self, path: &Path) -> Option<DocId> {
+        let metadata = self.documents.remove(path)?;
+
+        for postings in self.postings.values_mut() {
+            postings.remove(&metadata.id);
+        }
+        self.postings.retain(|_, postings| !postings.is_empty());
+        Some(metadata.id)
     }
 
     pub fn candidates_for_literal(&self, literal: &str) -> BTreeSet<DocId> {
@@ -134,6 +166,33 @@ where
             matches,
         }
     }
+}
+
+fn insert_document(
+    documents: &mut DocumentRegistry,
+    postings: &mut HashMap<Trigram, BTreeSet<DocId>>,
+    path: std::path::PathBuf,
+    content: &str,
+) -> DocId {
+    let doc_id = documents.insert_or_update(path, trigram_count(content), content.len() as u64);
+
+    for trigram in trigrams(content) {
+        postings.entry(trigram).or_default().insert(doc_id);
+    }
+
+    doc_id
+}
+
+fn sorted_doc_ids(
+    corpus_documents: &[super::CorpusDocument],
+    documents: &DocumentRegistry,
+) -> Vec<DocId> {
+    let mut doc_ids_by_path = corpus_documents
+        .iter()
+        .filter_map(|document| documents.doc_id(&document.path))
+        .collect::<Vec<_>>();
+    doc_ids_by_path.sort();
+    doc_ids_by_path
 }
 
 pub fn trigrams(content: &str) -> Vec<Trigram> {


### PR DESCRIPTION
- add `TrigramIndex::refresh_document` so a changed path can be reread into the regex trigram index without rebuilding the corpus
- add `TrigramIndex::remove_document` so deleted paths clear stale document metadata and postings
- share document insertion logic between initial indexing and single-path refreshes
- cover new, modified, and deleted file freshness with focused `regex_search` tests