### PR TITLE
feat(regex): add mmap regex postings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +987,7 @@ dependencies = [
  "config",
  "criterion",
  "dashmap",
+ "memmap2",
  "rayon",
  "regex",
  "rust-stemmers",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,7 @@ url = "^2.5"
 dashmap = "^6"
 thiserror = "^2.0"
 regex = "^1.12"
+memmap2 = "^0.9"
 
 [dev-dependencies]
 criterion = "^0.5"

--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -7,6 +7,10 @@ use std::{
 pub struct DocId(u32);
 
 impl DocId {
+    pub fn from_u32(value: u32) -> Self {
+        Self(value)
+    }
+
     pub fn as_u32(self) -> u32 {
         self.0
     }

--- a/crates/core/src/regex_search/disk_postings.rs
+++ b/crates/core/src/regex_search/disk_postings.rs
@@ -1,0 +1,362 @@
+use std::{
+    collections::{BTreeSet, HashMap},
+    fs::{self, File},
+    hash::{Hash, Hasher},
+    io::{self, Write},
+    ops::Range,
+    path::{Path, PathBuf},
+};
+
+use memmap2::{Mmap, MmapOptions};
+
+use super::{
+    RegexCandidatePlan, RegexCandidateSelection, RegexPostingsError, Trigram,
+    planner::{self, RegexPostingSource},
+};
+use crate::index::DocId;
+
+const LOOKUP_FILE_NAME: &str = "regex_lookup.bin";
+const POSTINGS_FILE_NAME: &str = "regex_postings.bin";
+const LOOKUP_MAGIC: &[u8; 8] = b"rrplu001";
+const POSTINGS_MAGIC: &[u8; 8] = b"rrpst001";
+const HEADER_LEN: usize = 16;
+const LOOKUP_ENTRY_LEN: usize = 24;
+const DOC_ID_LEN: usize = 4;
+
+#[derive(Debug)]
+pub struct MmapRegexPostings {
+    lookup: Mmap,
+    postings: Mmap,
+}
+
+impl MmapRegexPostings {
+    pub fn write(
+        directory: impl AsRef<Path>,
+        postings: &HashMap<Trigram, BTreeSet<DocId>>,
+    ) -> Result<(), RegexPostingsError> {
+        fs::create_dir_all(directory.as_ref())?;
+        let lookup_path = directory.as_ref().join(LOOKUP_FILE_NAME);
+        let postings_path = directory.as_ref().join(POSTINGS_FILE_NAME);
+
+        let mut lookup_entries = postings
+            .iter()
+            .map(|(trigram, doc_ids)| LookupEntry {
+                hash: trigram_hash(trigram),
+                offset: 0,
+                doc_count: doc_ids.len() as u64,
+                doc_ids,
+            })
+            .collect::<Vec<_>>();
+        lookup_entries.sort_by(|left, right| {
+            left.hash
+                .cmp(&right.hash)
+                .then_with(|| left.doc_ids.cmp(right.doc_ids))
+        });
+
+        let mut postings_file = File::create(postings_path)?;
+        postings_file.write_all(POSTINGS_MAGIC)?;
+        write_u64(&mut postings_file, lookup_entries.len() as u64)?;
+
+        let mut offset = HEADER_LEN as u64;
+        for entry in &mut lookup_entries {
+            entry.offset = offset;
+            for doc_id in entry.doc_ids {
+                write_u32(&mut postings_file, doc_id.as_u32())?;
+            }
+            offset += entry.doc_count * DOC_ID_LEN as u64;
+        }
+
+        let mut lookup_file = File::create(lookup_path)?;
+        lookup_file.write_all(LOOKUP_MAGIC)?;
+        write_u64(&mut lookup_file, lookup_entries.len() as u64)?;
+        for entry in lookup_entries {
+            write_u64(&mut lookup_file, entry.hash)?;
+            write_u64(&mut lookup_file, entry.offset)?;
+            write_u64(&mut lookup_file, entry.doc_count)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn open(directory: impl AsRef<Path>) -> Result<Self, RegexPostingsError> {
+        let lookup = mmap_read_only(directory.as_ref().join(LOOKUP_FILE_NAME))?;
+        let postings = mmap_read_only(directory.as_ref().join(POSTINGS_FILE_NAME))?;
+        validate_header(&lookup, LOOKUP_MAGIC)?;
+        validate_header(&postings, POSTINGS_MAGIC)?;
+        validate_lookup_len(&lookup)?;
+
+        Ok(Self { lookup, postings })
+    }
+
+    pub fn postings(
+        &self,
+        trigram: &Trigram,
+    ) -> Result<Option<BTreeSet<DocId>>, RegexPostingsError> {
+        let hash = trigram_hash(trigram);
+        let mut candidates = BTreeSet::new();
+        let entry_range = self.lookup_entry_range(hash)?;
+        let mut matched = false;
+
+        for index in entry_range {
+            let entry = self.lookup_entry(index)?;
+            matched = true;
+            candidates.extend(self.read_posting_list(entry.offset, entry.doc_count)?);
+        }
+
+        Ok(matched.then_some(candidates))
+    }
+
+    pub fn planned_candidates_for_regex_plan(
+        &self,
+        plan: &RegexCandidatePlan,
+        all_doc_ids: &[DocId],
+    ) -> Result<RegexCandidateSelection, RegexPostingsError> {
+        planner::try_plan_candidates(plan, self, all_doc_ids)
+    }
+
+    pub fn lookup_entry_count(&self) -> Result<usize, RegexPostingsError> {
+        read_count(&self.lookup)
+    }
+
+    pub fn mapped_bytes(&self) -> usize {
+        self.lookup.len() + self.postings.len()
+    }
+
+    fn lookup_entry(&self, index: usize) -> Result<StoredLookupEntry, RegexPostingsError> {
+        let start = HEADER_LEN + index * LOOKUP_ENTRY_LEN;
+        let end = start + LOOKUP_ENTRY_LEN;
+        let bytes = self
+            .lookup
+            .get(start..end)
+            .ok_or(RegexPostingsError::InvalidFormat)?;
+
+        Ok(StoredLookupEntry {
+            hash: read_u64(&bytes[0..8])?,
+            offset: read_u64(&bytes[8..16])?,
+            doc_count: read_u64(&bytes[16..24])?,
+        })
+    }
+
+    fn posting_len_for_hash(&self, hash: u64) -> Result<Option<usize>, RegexPostingsError> {
+        let mut posting_len = 0usize;
+        let entry_range = self.lookup_entry_range(hash)?;
+        let mut matched = false;
+
+        for index in entry_range {
+            let entry = self.lookup_entry(index)?;
+            matched = true;
+            posting_len = posting_len
+                .checked_add(
+                    usize::try_from(entry.doc_count)
+                        .map_err(|_| RegexPostingsError::FileTooLarge)?,
+                )
+                .ok_or(RegexPostingsError::FileTooLarge)?;
+        }
+
+        Ok(matched.then_some(posting_len))
+    }
+
+    fn lookup_entry_range(&self, hash: u64) -> Result<Range<usize>, RegexPostingsError> {
+        let entry_count = read_count(&self.lookup)?;
+        let lower = self.partition_point(entry_count, |entry_hash| entry_hash < hash)?;
+        let upper = self.partition_point(entry_count, |entry_hash| entry_hash <= hash)?;
+        Ok(lower..upper)
+    }
+
+    fn partition_point(
+        &self,
+        entry_count: usize,
+        predicate: impl Fn(u64) -> bool,
+    ) -> Result<usize, RegexPostingsError> {
+        let mut left = 0;
+        let mut right = entry_count;
+
+        while left < right {
+            let mid = left + (right - left) / 2;
+            let entry = self.lookup_entry(mid)?;
+            if predicate(entry.hash) {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+
+        Ok(left)
+    }
+
+    fn read_posting_list(
+        &self,
+        offset: u64,
+        doc_count: u64,
+    ) -> Result<BTreeSet<DocId>, RegexPostingsError> {
+        let start = usize::try_from(offset).map_err(|_| RegexPostingsError::FileTooLarge)?;
+        let byte_len = usize::try_from(doc_count)
+            .map_err(|_| RegexPostingsError::FileTooLarge)?
+            .checked_mul(DOC_ID_LEN)
+            .ok_or(RegexPostingsError::FileTooLarge)?;
+        let end = start
+            .checked_add(byte_len)
+            .ok_or(RegexPostingsError::FileTooLarge)?;
+        let bytes = self
+            .postings
+            .get(start..end)
+            .ok_or(RegexPostingsError::InvalidFormat)?;
+
+        bytes
+            .chunks_exact(DOC_ID_LEN)
+            .map(|chunk| read_u32(chunk).map(DocId::from_u32))
+            .collect()
+    }
+}
+
+impl RegexPostingSource for MmapRegexPostings {
+    type Error = RegexPostingsError;
+
+    fn posting_len(&self, trigram: &Trigram) -> Result<Option<usize>, Self::Error> {
+        self.posting_len_for_hash(trigram_hash(trigram))
+    }
+
+    fn postings(&self, trigram: &Trigram) -> Result<Option<BTreeSet<DocId>>, Self::Error> {
+        Self::postings(self, trigram)
+    }
+}
+
+#[derive(Debug)]
+struct LookupEntry<'a> {
+    hash: u64,
+    offset: u64,
+    doc_count: u64,
+    doc_ids: &'a BTreeSet<DocId>,
+}
+
+#[derive(Debug)]
+struct StoredLookupEntry {
+    hash: u64,
+    offset: u64,
+    doc_count: u64,
+}
+
+fn mmap_read_only(path: PathBuf) -> Result<Mmap, RegexPostingsError> {
+    let file = File::open(path)?;
+    // SAFETY: Repo Reaper writes immutable index files and opens them read-only here.
+    // Callers must replace an index by writing new files instead of mutating mapped bytes.
+    let mmap = unsafe { MmapOptions::new().map(&file)? };
+    Ok(mmap)
+}
+
+fn validate_header(bytes: &[u8], magic: &[u8; 8]) -> Result<(), RegexPostingsError> {
+    if bytes.len() < HEADER_LEN || &bytes[..8] != magic {
+        return Err(RegexPostingsError::InvalidFormat);
+    }
+    Ok(())
+}
+
+fn validate_lookup_len(bytes: &[u8]) -> Result<(), RegexPostingsError> {
+    let entry_count = read_count(bytes)?;
+    let entries_len = entry_count
+        .checked_mul(LOOKUP_ENTRY_LEN)
+        .ok_or(RegexPostingsError::FileTooLarge)?;
+    let expected_len = HEADER_LEN
+        .checked_add(entries_len)
+        .ok_or(RegexPostingsError::FileTooLarge)?;
+
+    if bytes.len() != expected_len {
+        return Err(RegexPostingsError::InvalidFormat);
+    }
+
+    Ok(())
+}
+
+fn read_count(bytes: &[u8]) -> Result<usize, RegexPostingsError> {
+    usize::try_from(read_u64(&bytes[8..16])?).map_err(|_| RegexPostingsError::FileTooLarge)
+}
+
+fn trigram_hash(trigram: &Trigram) -> u64 {
+    let mut hasher = StableHasher::default();
+    trigram.as_str().hash(&mut hasher);
+    hasher.finish()
+}
+
+#[derive(Default)]
+struct StableHasher(u64);
+
+impl Hasher for StableHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+        if self.0 == 0 {
+            self.0 = 0xcbf2_9ce4_8422_2325;
+        }
+        for byte in bytes {
+            self.0 ^= u64::from(*byte);
+            self.0 = self.0.wrapping_mul(FNV_PRIME);
+        }
+    }
+
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+fn write_u32(writer: &mut impl Write, value: u32) -> io::Result<()> {
+    writer.write_all(&value.to_le_bytes())
+}
+
+fn write_u64(writer: &mut impl Write, value: u64) -> io::Result<()> {
+    writer.write_all(&value.to_le_bytes())
+}
+
+fn read_u32(bytes: &[u8]) -> Result<u32, RegexPostingsError> {
+    let bytes: [u8; 4] = bytes
+        .try_into()
+        .map_err(|_| RegexPostingsError::InvalidFormat)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_u64(bytes: &[u8]) -> Result<u64, RegexPostingsError> {
+    let bytes: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| RegexPostingsError::InvalidFormat)?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_collisions_union_posting_lists_as_broader_candidates() {
+        let temp = tempfile::tempdir().unwrap();
+        let hash = trigram_hash(&Trigram::from("abc"));
+        let lookup_path = temp.path().join(LOOKUP_FILE_NAME);
+        let postings_path = temp.path().join(POSTINGS_FILE_NAME);
+
+        let mut postings_file = File::create(postings_path).unwrap();
+        postings_file.write_all(POSTINGS_MAGIC).unwrap();
+        write_u64(&mut postings_file, 2).unwrap();
+        write_u32(&mut postings_file, 1).unwrap();
+        write_u32(&mut postings_file, 2).unwrap();
+        write_u32(&mut postings_file, 3).unwrap();
+
+        let mut lookup_file = File::create(lookup_path).unwrap();
+        lookup_file.write_all(LOOKUP_MAGIC).unwrap();
+        write_u64(&mut lookup_file, 2).unwrap();
+        write_u64(&mut lookup_file, hash).unwrap();
+        write_u64(&mut lookup_file, HEADER_LEN as u64).unwrap();
+        write_u64(&mut lookup_file, 2).unwrap();
+        write_u64(&mut lookup_file, hash).unwrap();
+        write_u64(&mut lookup_file, (HEADER_LEN + 2 * DOC_ID_LEN) as u64).unwrap();
+        write_u64(&mut lookup_file, 1).unwrap();
+        drop(lookup_file);
+        drop(postings_file);
+
+        let postings = MmapRegexPostings::open(temp.path()).unwrap();
+        let doc_ids = postings.postings(&Trigram::from("abc")).unwrap().unwrap();
+
+        assert_eq!(
+            doc_ids,
+            [DocId::from_u32(1), DocId::from_u32(2), DocId::from_u32(3)]
+                .into_iter()
+                .collect()
+        );
+    }
+}

--- a/crates/core/src/regex_search/mod.rs
+++ b/crates/core/src/regex_search/mod.rs
@@ -1,4 +1,5 @@
 mod corpus;
+mod disk_postings;
 mod engine;
 mod planner;
 mod regex_query;
@@ -8,12 +9,13 @@ mod types;
 use std::ops::{Range, RangeInclusive};
 
 pub use corpus::{CorpusDocument, FileSystemCorpus, RegexCorpus};
+pub use disk_postings::MmapRegexPostings;
 pub use engine::RegexSearchEngine;
 pub use regex_query::RegexCandidatePlan;
 pub use trigram_index::{TrigramIndex, trigrams};
 pub use types::{
-    LiteralSearchResult, RegexCandidateDiagnostics, RegexCandidateSelection, RegexSearchError,
-    RegexSearchMatch, Trigram,
+    LiteralSearchResult, RegexCandidateDiagnostics, RegexCandidateSelection, RegexPostingsError,
+    RegexSearchError, RegexSearchMatch, Trigram,
 };
 
 pub(crate) fn line_range_for_match(

--- a/crates/core/src/regex_search/planner.rs
+++ b/crates/core/src/regex_search/planner.rs
@@ -1,17 +1,50 @@
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    convert::Infallible,
+};
 
 use super::{RegexCandidateDiagnostics, RegexCandidatePlan, RegexCandidateSelection, Trigram};
 use crate::index::DocId;
 
 const MAX_SELECTED_TRIGRAMS: usize = 8;
 
+pub(crate) trait RegexPostingSource {
+    type Error;
+
+    fn posting_len(&self, trigram: &Trigram) -> Result<Option<usize>, Self::Error>;
+    fn postings(&self, trigram: &Trigram) -> Result<Option<BTreeSet<DocId>>, Self::Error>;
+}
+
+impl RegexPostingSource for HashMap<Trigram, BTreeSet<DocId>> {
+    type Error = Infallible;
+
+    fn posting_len(&self, trigram: &Trigram) -> Result<Option<usize>, Self::Error> {
+        Ok(self.get(trigram).map(BTreeSet::len))
+    }
+
+    fn postings(&self, trigram: &Trigram) -> Result<Option<BTreeSet<DocId>>, Self::Error> {
+        Ok(self.get(trigram).cloned())
+    }
+}
+
 pub(crate) fn plan_candidates(
     plan: &RegexCandidatePlan,
     postings: &HashMap<Trigram, BTreeSet<DocId>>,
     all_doc_ids: &[DocId],
 ) -> RegexCandidateSelection {
+    try_plan_candidates(plan, postings, all_doc_ids).unwrap_or_else(|never| match never {})
+}
+
+pub(crate) fn try_plan_candidates<S>(
+    plan: &RegexCandidatePlan,
+    postings: &S,
+    all_doc_ids: &[DocId],
+) -> Result<RegexCandidateSelection, S::Error>
+where
+    S: RegexPostingSource,
+{
     match plan {
-        RegexCandidatePlan::All => all_candidates(all_doc_ids),
+        RegexCandidatePlan::All => Ok(all_candidates(all_doc_ids)),
         RegexCandidatePlan::And(trigrams) => plan_conjunction(trigrams, postings, all_doc_ids),
         RegexCandidatePlan::Or(branches) => plan_disjunction(branches, postings, all_doc_ids),
     }
@@ -22,50 +55,56 @@ fn all_candidates(all_doc_ids: &[DocId]) -> RegexCandidateSelection {
     selection(candidates, all_doc_ids.len(), Vec::new(), true)
 }
 
-fn plan_disjunction(
+fn plan_disjunction<S>(
     branches: &[RegexCandidatePlan],
-    postings: &HashMap<Trigram, BTreeSet<DocId>>,
+    postings: &S,
     all_doc_ids: &[DocId],
-) -> RegexCandidateSelection {
+) -> Result<RegexCandidateSelection, S::Error>
+where
+    S: RegexPostingSource,
+{
     let mut candidates = BTreeSet::new();
     let mut selected_trigrams = Vec::new();
     let mut fell_back_to_full_scan = false;
 
     for branch in branches {
-        let branch_selection = plan_candidates(branch, postings, all_doc_ids);
+        let branch_selection = try_plan_candidates(branch, postings, all_doc_ids)?;
         candidates.extend(branch_selection.candidates);
         selected_trigrams.extend(branch_selection.diagnostics.selected_trigrams);
         fell_back_to_full_scan |= branch_selection.diagnostics.fell_back_to_full_scan;
     }
 
-    selection(
+    Ok(selection(
         candidates,
         all_doc_ids.len(),
         selected_trigrams,
         fell_back_to_full_scan,
-    )
+    ))
 }
 
-fn plan_conjunction(
+fn plan_conjunction<S>(
     trigrams: &[Trigram],
-    postings: &HashMap<Trigram, BTreeSet<DocId>>,
+    postings: &S,
     all_doc_ids: &[DocId],
-) -> RegexCandidateSelection {
+) -> Result<RegexCandidateSelection, S::Error>
+where
+    S: RegexPostingSource,
+{
     if trigrams.is_empty() {
-        return all_candidates(all_doc_ids);
+        return Ok(all_candidates(all_doc_ids));
     }
 
     let mut posting_sizes = Vec::with_capacity(trigrams.len());
     for trigram in trigrams {
-        let Some(posting) = postings.get(trigram) else {
-            return selection(
+        let Some(posting_len) = postings.posting_len(trigram)? else {
+            return Ok(selection(
                 BTreeSet::new(),
                 all_doc_ids.len(),
                 vec![trigram.clone()],
                 false,
-            );
+            ));
         };
-        posting_sizes.push((trigram, posting.len()));
+        posting_sizes.push((trigram, posting_len));
     }
 
     posting_sizes.sort_by(|(left_trigram, left_len), (right_trigram, right_len)| {
@@ -89,31 +128,36 @@ fn plan_conjunction(
     }
 
     if selected_trigrams.is_empty() {
-        return all_candidates(all_doc_ids);
+        return Ok(all_candidates(all_doc_ids));
     }
 
-    let candidates = intersect_postings(&selected_trigrams, postings);
-    selection(candidates, all_doc_ids.len(), selected_trigrams, false)
+    let candidates = intersect_postings(&selected_trigrams, postings)?;
+    Ok(selection(
+        candidates,
+        all_doc_ids.len(),
+        selected_trigrams,
+        false,
+    ))
 }
 
-fn intersect_postings(
-    trigrams: &[Trigram],
-    postings: &HashMap<Trigram, BTreeSet<DocId>>,
-) -> BTreeSet<DocId> {
+fn intersect_postings<S>(trigrams: &[Trigram], postings: &S) -> Result<BTreeSet<DocId>, S::Error>
+where
+    S: RegexPostingSource,
+{
     let Some((first, rest)) = trigrams.split_first() else {
-        return BTreeSet::new();
+        return Ok(BTreeSet::new());
     };
 
-    let mut candidates = postings.get(first).cloned().unwrap_or_else(BTreeSet::new);
+    let mut candidates = postings.postings(first)?.unwrap_or_default();
 
     for trigram in rest {
-        let Some(posting) = postings.get(trigram) else {
-            return BTreeSet::new();
+        let Some(posting) = postings.postings(trigram)? else {
+            return Ok(BTreeSet::new());
         };
-        candidates = candidates.intersection(posting).copied().collect();
+        candidates = candidates.intersection(&posting).copied().collect();
     }
 
-    candidates
+    Ok(candidates)
 }
 
 fn selection(

--- a/crates/core/src/regex_search/tests.rs
+++ b/crates/core/src/regex_search/tests.rs
@@ -6,8 +6,8 @@ use std::{
 use regex::Regex;
 
 use super::{
-    CorpusDocument, RegexCandidatePlan, RegexCorpus, RegexSearchEngine, Trigram, TrigramIndex,
-    trigrams,
+    CorpusDocument, MmapRegexPostings, RegexCandidatePlan, RegexCorpus, RegexSearchEngine, Trigram,
+    TrigramIndex, trigrams,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -528,6 +528,60 @@ fn removing_document_prevents_deleted_file_from_leaking_candidates() {
 }
 
 #[test]
+fn mmap_postings_round_trip_lookup_matches_in_memory_postings() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("first.rs", "abcdef"),
+        ("second.rs", "zabczz"),
+        ("third.rs", "uvwxyz"),
+    ]));
+    let temp = tempfile::tempdir().unwrap();
+
+    index.write_mmap_postings(temp.path()).unwrap();
+    let postings = MmapRegexPostings::open(temp.path()).unwrap();
+    let mmap_doc_ids = postings.postings(&Trigram::from("abc")).unwrap().unwrap();
+
+    assert_eq!(
+        mmap_doc_ids,
+        index.postings(&Trigram::from("abc")).unwrap().clone()
+    );
+    assert_eq!(postings.lookup_entry_count().unwrap(), 11);
+    assert!(postings.mapped_bytes() > 0);
+}
+
+#[test]
+fn mmap_postings_drive_same_candidate_plan_as_memory_postings() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "xxabcdefyy"),
+        ("false_positive.rs", "abc bcd cde def"),
+        ("missing.rs", "abxde"),
+    ]));
+    let temp = tempfile::tempdir().unwrap();
+    let all_doc_ids = doc_ids_for_paths(&index, &["false_positive.rs", "match.rs", "missing.rs"]);
+    let plan = RegexCandidatePlan::for_pattern("abcdef");
+    let memory_candidates = index.candidates_for_regex_plan(&plan);
+
+    index.write_mmap_postings(temp.path()).unwrap();
+    let postings = MmapRegexPostings::open(temp.path()).unwrap();
+    let mmap_candidates = postings
+        .planned_candidates_for_regex_plan(&plan, &all_doc_ids)
+        .unwrap()
+        .candidates;
+
+    assert_eq!(mmap_candidates, memory_candidates);
+}
+
+#[test]
+fn mmap_postings_report_missing_trigram_without_full_deserialization() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[("a.rs", "abcdef")]));
+    let temp = tempfile::tempdir().unwrap();
+
+    index.write_mmap_postings(temp.path()).unwrap();
+    let postings = MmapRegexPostings::open(temp.path()).unwrap();
+
+    assert!(postings.postings(&Trigram::from("zzz")).unwrap().is_none());
+}
+
+#[test]
 fn unsupported_regex_constructs_fall_back_to_broader_candidates() {
     let index = TrigramIndex::with_corpus(TestCorpus::new(&[
         ("match.rs", "foo123bar"),
@@ -536,6 +590,15 @@ fn unsupported_regex_constructs_fall_back_to_broader_candidates() {
     let candidates = index.candidates_for_regex(r"foo\d+bar");
 
     assert!(candidates.contains(&index.doc_id(Path::new("match.rs")).unwrap()));
+}
+
+fn doc_ids_for_paths(index: &TrigramIndex<TestCorpus>, paths: &[&str]) -> Vec<crate::index::DocId> {
+    let mut doc_ids = paths
+        .iter()
+        .map(|path| index.doc_id(Path::new(path)).unwrap())
+        .collect::<Vec<_>>();
+    doc_ids.sort();
+    doc_ids
 }
 
 fn write_file(root: &Path, path: &str, content: &str) -> std::io::Result<()> {

--- a/crates/core/src/regex_search/trigram_index.rs
+++ b/crates/core/src/regex_search/trigram_index.rs
@@ -5,8 +5,9 @@ use std::{
 };
 
 use super::{
-    FileSystemCorpus, LiteralSearchResult, RegexCandidatePlan, RegexCandidateSelection,
-    RegexCorpus, RegexSearchMatch, Trigram, line_range_for_match, planner,
+    FileSystemCorpus, LiteralSearchResult, MmapRegexPostings, RegexCandidatePlan,
+    RegexCandidateSelection, RegexCorpus, RegexPostingsError, RegexSearchMatch, Trigram,
+    line_range_for_match, planner,
 };
 use crate::index::{
     DocId,
@@ -134,6 +135,13 @@ where
         plan: &RegexCandidatePlan,
     ) -> RegexCandidateSelection {
         planner::plan_candidates(plan, &self.postings, &self.doc_ids_by_path)
+    }
+
+    pub fn write_mmap_postings(
+        &self,
+        directory: impl AsRef<Path>,
+    ) -> Result<(), RegexPostingsError> {
+        MmapRegexPostings::write(directory, &self.postings)
     }
 
     pub fn search_literal(&self, literal: &str) -> LiteralSearchResult {

--- a/crates/core/src/regex_search/types.rs
+++ b/crates/core/src/regex_search/types.rs
@@ -12,6 +12,16 @@ pub enum RegexSearchError {
     InvalidPattern(#[source] regex::Error),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum RegexPostingsError {
+    #[error("regex postings io failed")]
+    Io(#[from] std::io::Error),
+    #[error("invalid regex postings format")]
+    InvalidFormat,
+    #[error("regex postings file is too large")]
+    FileTooLarge,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegexSearchMatch {
     pub path: PathBuf,


### PR DESCRIPTION
- add `memmap2` and a compact two-file regex postings format with sorted lookup entries and packed `DocId` postings
- introduce a `RegexPostingSource` trait so the candidate planner can use either in-memory postings or `MmapRegexPostings`
- add `MmapRegexPostings` read-only mmap loading, binary-search lookup, mapped-byte diagnostics, and collision-safe posting unions
- add `TrigramIndex::write_mmap_postings` as the small bridge from the current in-memory index to the on-disk format
- cover mmap round trips, planner parity, missing trigrams, and hash-collision broadening with focused tests