### PR TITLE
feat(regex): add experimental candidate masks

### DIFF
--- a/crates/core/src/regex_search/candidate_mask.rs
+++ b/crates/core/src/regex_search/candidate_mask.rs
@@ -1,0 +1,155 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use super::{Trigram, trigrams};
+use crate::index::DocId;
+
+const POSITION_BUCKETS: u8 = 8;
+const NEXT_CHAR_BUCKETS: u32 = 128;
+
+#[derive(Debug, Default)]
+pub(crate) struct RegexCandidateMask {
+    masks: HashMap<Trigram, BTreeMap<DocId, TrigramDocumentMask>>,
+}
+
+impl RegexCandidateMask {
+    pub(crate) fn add_document(&mut self, doc_id: DocId, content: &str) {
+        let chars = content.chars().collect::<Vec<_>>();
+        for (offset, window) in chars.windows(3).enumerate() {
+            let trigram = Trigram(window.iter().collect());
+            let mask = self
+                .masks
+                .entry(trigram)
+                .or_default()
+                .entry(doc_id)
+                .or_default();
+            mask.add_position(offset);
+            if let Some(&next_char) = chars.get(offset + 3) {
+                mask.add_next_char(next_char);
+            }
+        }
+    }
+
+    pub(crate) fn remove_document(&mut self, doc_id: DocId) {
+        for document_masks in self.masks.values_mut() {
+            document_masks.remove(&doc_id);
+        }
+        self.masks
+            .retain(|_, document_masks| !document_masks.is_empty());
+    }
+
+    pub(crate) fn filter_literal(
+        &self,
+        literal: &str,
+        candidates: &BTreeSet<DocId>,
+    ) -> BTreeSet<DocId> {
+        let requirements = LiteralMaskRequirements::new(literal);
+        if !requirements.is_selective() {
+            return candidates.clone();
+        }
+
+        candidates
+            .iter()
+            .copied()
+            .filter(|&doc_id| self.doc_may_match_literal(doc_id, &requirements))
+            .collect()
+    }
+
+    fn doc_may_match_literal(&self, doc_id: DocId, requirements: &LiteralMaskRequirements) -> bool {
+        (0..POSITION_BUCKETS).any(|start_bucket| {
+            self.doc_matches_at_start_bucket(doc_id, requirements, start_bucket)
+        })
+    }
+
+    fn doc_matches_at_start_bucket(
+        &self,
+        doc_id: DocId,
+        requirements: &LiteralMaskRequirements,
+        start_bucket: u8,
+    ) -> bool {
+        requirements.iter().all(|requirement| {
+            let Some(mask) = self
+                .masks
+                .get(&requirement.trigram)
+                .and_then(|document_masks| document_masks.get(&doc_id))
+            else {
+                return true;
+            };
+
+            let position_bucket = (start_bucket + requirement.offset_bucket) % POSITION_BUCKETS;
+            mask.has_position(position_bucket)
+                && requirement
+                    .next_char
+                    .is_none_or(|next_char| mask.has_next_char(next_char))
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct TrigramDocumentMask {
+    position_buckets: u8,
+    next_char_buckets: u128,
+}
+
+impl TrigramDocumentMask {
+    fn add_position(&mut self, offset: usize) {
+        let bucket = (offset as u8) % POSITION_BUCKETS;
+        self.position_buckets |= 1_u8 << bucket;
+    }
+
+    fn add_next_char(&mut self, char_: char) {
+        self.next_char_buckets |= next_char_bit(char_);
+    }
+
+    fn has_position(&self, bucket: u8) -> bool {
+        self.position_buckets & (1_u8 << bucket) != 0
+    }
+
+    fn has_next_char(&self, char_: char) -> bool {
+        self.next_char_buckets & next_char_bit(char_) != 0
+    }
+}
+
+#[derive(Debug)]
+struct LiteralMaskRequirements {
+    requirements: Vec<LiteralMaskRequirement>,
+}
+
+impl LiteralMaskRequirements {
+    fn new(literal: &str) -> Self {
+        let chars = literal.chars().collect::<Vec<_>>();
+        let literal_trigrams = trigrams(literal);
+        let requirements = literal_trigrams
+            .into_iter()
+            .enumerate()
+            .map(|(offset, trigram)| LiteralMaskRequirement {
+                trigram,
+                offset_bucket: (offset as u8) % POSITION_BUCKETS,
+                next_char: chars.get(offset + 3).copied(),
+            })
+            .collect();
+
+        Self { requirements }
+    }
+
+    fn is_selective(&self) -> bool {
+        self.requirements
+            .iter()
+            .any(|requirement| requirement.next_char.is_some())
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &LiteralMaskRequirement> {
+        self.requirements.iter()
+    }
+}
+
+#[derive(Debug)]
+struct LiteralMaskRequirement {
+    trigram: Trigram,
+    offset_bucket: u8,
+    next_char: Option<char>,
+}
+
+fn next_char_bit(char_: char) -> u128 {
+    let bucket = (char_ as u32) % NEXT_CHAR_BUCKETS;
+    1_u128 << bucket
+}

--- a/crates/core/src/regex_search/mod.rs
+++ b/crates/core/src/regex_search/mod.rs
@@ -1,3 +1,4 @@
+mod candidate_mask;
 mod corpus;
 mod disk_postings;
 mod engine;

--- a/crates/core/src/regex_search/tests.rs
+++ b/crates/core/src/regex_search/tests.rs
@@ -228,6 +228,96 @@ fn literal_candidates_are_supersets_of_true_matches() {
 }
 
 #[test]
+fn experimental_masks_reduce_phrase_like_literal_false_positives() {
+    let matching = PathBuf::from("match.rs");
+    let plain_false_positive = PathBuf::from("plain_false_positive.rs");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "xxabcdefxx"),
+        ("plain_false_positive.rs", "abc bcd cde def"),
+        ("missing.rs", "abxde"),
+    ]));
+
+    let plain_candidates = index.candidates_for_literal("abcdef");
+    let masked_candidates = index.experimental_masked_candidates_for_literal("abcdef");
+
+    assert_eq!(plain_candidates.len(), 2);
+    assert!(plain_candidates.contains(&index.doc_id(&plain_false_positive).unwrap()));
+    assert_eq!(masked_candidates.len(), 1);
+    assert!(masked_candidates.contains(&index.doc_id(&matching).unwrap()));
+}
+
+#[test]
+fn experimental_regex_masks_reduce_plain_literal_pattern_false_positives() {
+    let matching = PathBuf::from("match.rs");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "xxabcdefxx"),
+        ("plain_false_positive.rs", "abc bcd cde def"),
+    ]));
+
+    let plain_candidates = index.candidates_for_regex("abcdef");
+    let masked_candidates = index.experimental_masked_candidates_for_regex("abcdef");
+
+    assert_eq!(plain_candidates.len(), 2);
+    assert_eq!(masked_candidates.len(), 1);
+    assert!(masked_candidates.contains(&index.doc_id(&matching).unwrap()));
+}
+
+#[test]
+fn experimental_regex_masks_fall_back_for_unsupported_patterns() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "foo123bar"),
+        ("other.rs", "fooabcbar"),
+    ]));
+
+    assert_eq!(
+        index.experimental_masked_candidates_for_regex(r"foo\d+bar"),
+        index.candidates_for_regex(r"foo\d+bar")
+    );
+}
+
+#[test]
+fn experimental_masks_keep_all_verified_literal_matches() {
+    let documents = [
+        ("start.rs", "abcdef at start"),
+        ("middle.rs", "xx abcdef yy"),
+        ("repeated.rs", "abcabc abcdef"),
+        ("false_positive.rs", "abc bcd cde def"),
+    ];
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&documents));
+    let masked_candidates = index.experimental_masked_candidates_for_literal("abcdef");
+
+    for (path, content) in documents {
+        if content.contains("abcdef") {
+            let doc_id = index.doc_id(Path::new(path)).unwrap();
+            assert!(masked_candidates.contains(&doc_id));
+        }
+    }
+}
+
+#[test]
+fn experimental_masks_fall_back_for_short_literals() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[("a.rs", "ab"), ("b.rs", "zz")]));
+
+    assert_eq!(
+        index.experimental_masked_candidates_for_literal("ab"),
+        index.candidates_for_literal("ab")
+    );
+}
+
+#[test]
+fn experimental_masks_keep_repeated_overlapping_trigram_matches() {
+    let matching = PathBuf::from("match.rs");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "aaaaaa"),
+        ("near.rs", "aaa aaa"),
+    ]));
+
+    let masked_candidates = index.experimental_masked_candidates_for_literal("aaaaa");
+
+    assert!(masked_candidates.contains(&index.doc_id(&matching).unwrap()));
+}
+
+#[test]
 fn short_literal_candidates_include_all_indexed_documents() {
     let first = PathBuf::from("a.rs");
     let second = PathBuf::from("b.rs");

--- a/crates/core/src/regex_search/trigram_index.rs
+++ b/crates/core/src/regex_search/trigram_index.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{
     FileSystemCorpus, LiteralSearchResult, MmapRegexPostings, RegexCandidatePlan,
     RegexCandidateSelection, RegexCorpus, RegexPostingsError, RegexSearchMatch, Trigram,
-    line_range_for_match, planner,
+    candidate_mask::RegexCandidateMask, line_range_for_match, planner,
 };
 use crate::index::{
     DocId,
@@ -18,6 +18,7 @@ use crate::index::{
 pub struct TrigramIndex<C = FileSystemCorpus> {
     corpus: C,
     postings: HashMap<Trigram, BTreeSet<DocId>>,
+    masks: RegexCandidateMask,
     documents: DocumentRegistry,
     doc_ids_by_path: Vec<DocId>,
 }
@@ -35,6 +36,7 @@ where
     pub fn with_corpus(corpus: C) -> Self {
         let mut documents = DocumentRegistry::new();
         let mut postings: HashMap<Trigram, BTreeSet<DocId>> = HashMap::new();
+        let mut masks = RegexCandidateMask::default();
         let mut corpus_documents = corpus.documents();
         corpus_documents.sort_by(|left, right| left.path.cmp(&right.path));
 
@@ -42,6 +44,7 @@ where
             insert_document(
                 &mut documents,
                 &mut postings,
+                &mut masks,
                 document.path.clone(),
                 &document.content,
             );
@@ -52,6 +55,7 @@ where
         Self {
             corpus,
             postings,
+            masks,
             documents,
             doc_ids_by_path,
         }
@@ -84,6 +88,7 @@ where
             let doc_id = insert_document(
                 &mut self.documents,
                 &mut self.postings,
+                &mut self.masks,
                 path.to_path_buf(),
                 &content,
             );
@@ -109,6 +114,7 @@ where
             postings.remove(&metadata.id);
         }
         self.postings.retain(|_, postings| !postings.is_empty());
+        self.masks.remove_document(metadata.id);
         Some(metadata.id)
     }
 
@@ -124,6 +130,21 @@ where
 
     pub fn candidates_for_regex_plan(&self, plan: &RegexCandidatePlan) -> BTreeSet<DocId> {
         self.planned_candidates_for_regex_plan(plan).candidates
+    }
+
+    pub fn experimental_masked_candidates_for_regex(&self, pattern: &str) -> BTreeSet<DocId> {
+        let plan = RegexCandidatePlan::for_pattern(pattern);
+        let plain_candidates = self.candidates_for_regex_plan(&plan);
+        if is_plain_literal_plan(pattern, &plan) {
+            self.masks.filter_literal(pattern, &plain_candidates)
+        } else {
+            plain_candidates
+        }
+    }
+
+    pub fn experimental_masked_candidates_for_literal(&self, literal: &str) -> BTreeSet<DocId> {
+        let plain_candidates = self.candidates_for_literal(literal);
+        self.masks.filter_literal(literal, &plain_candidates)
     }
 
     pub fn planned_candidates_for_regex(&self, pattern: &str) -> RegexCandidateSelection {
@@ -179,6 +200,7 @@ where
 fn insert_document(
     documents: &mut DocumentRegistry,
     postings: &mut HashMap<Trigram, BTreeSet<DocId>>,
+    masks: &mut RegexCandidateMask,
     path: std::path::PathBuf,
     content: &str,
 ) -> DocId {
@@ -187,6 +209,7 @@ fn insert_document(
     for trigram in trigrams(content) {
         postings.entry(trigram).or_default().insert(doc_id);
     }
+    masks.add_document(doc_id, content);
 
     doc_id
 }
@@ -213,6 +236,14 @@ pub fn trigrams(content: &str) -> Vec<Trigram> {
 
 fn trigram_count(content: &str) -> usize {
     content.chars().count().saturating_sub(2)
+}
+
+fn is_plain_literal_plan(pattern: &str, plan: &RegexCandidatePlan) -> bool {
+    let RegexCandidatePlan::And(plan_trigrams) = plan else {
+        return false;
+    };
+
+    *plan_trigrams == trigrams(pattern)
 }
 
 fn verified_literal_matches(path: &Path, content: &str, literal: &str) -> Vec<RegexSearchMatch> {


### PR DESCRIPTION
- `trigramindex` now maintains private per-document trigram masks alongside existing postings
- experimental literal and plain-regex candidate paths can reject phrase-like false positives with next-character and position-modulo masks
- unsupported regex shapes and short literals keep the existing broader candidate behavior
- regex tests cover candidate reduction, true-match preservation, fallback behavior, and repeated overlapping trigrams