### PR TITLE
feat(regex): add sparse ngram experiment

### DIFF
--- a/crates/core/src/regex_search/mod.rs
+++ b/crates/core/src/regex_search/mod.rs
@@ -4,6 +4,7 @@ mod disk_postings;
 mod engine;
 mod planner;
 mod regex_query;
+mod sparse_ngram;
 mod trigram_index;
 mod types;
 
@@ -15,8 +16,8 @@ pub use engine::RegexSearchEngine;
 pub use regex_query::RegexCandidatePlan;
 pub use trigram_index::{TrigramIndex, trigrams};
 pub use types::{
-    LiteralSearchResult, RegexCandidateDiagnostics, RegexCandidateSelection, RegexPostingsError,
-    RegexSearchError, RegexSearchMatch, Trigram,
+    ExperimentalSparseNgramComparison, LiteralSearchResult, RegexCandidateDiagnostics,
+    RegexCandidateSelection, RegexPostingsError, RegexSearchError, RegexSearchMatch, Trigram,
 };
 
 pub(crate) fn line_range_for_match(

--- a/crates/core/src/regex_search/sparse_ngram.rs
+++ b/crates/core/src/regex_search/sparse_ngram.rs
@@ -1,0 +1,79 @@
+use std::collections::BTreeSet;
+
+/// Advanced learning-track sparse n-gram primitives.
+///
+/// This module intentionally sits beside the classic trigram planner instead
+/// of replacing it. The weight function is a small stable in-repo hash so tests
+/// and future on-disk experiments are not tied to std hasher implementation
+/// details.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct SparseNgram(pub(crate) String);
+
+pub(crate) fn sparse_ngrams(content: &str) -> Vec<SparseNgram> {
+    let chars = content.chars().collect::<Vec<_>>();
+    let weights = pair_weights(&chars);
+    if weights.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ngrams = BTreeSet::new();
+    for start in 0..weights.len() {
+        for end in start..weights.len() {
+            if interval_is_sparse(&weights, start, end) {
+                ngrams.insert(chars[start..=end + 1].iter().collect::<String>());
+            }
+        }
+    }
+
+    ngrams.into_iter().map(SparseNgram).collect()
+}
+
+pub(crate) fn sparse_covering_ngrams(content: &str) -> Vec<SparseNgram> {
+    let chars = content.chars().collect::<Vec<_>>();
+    let weights = pair_weights(&chars);
+    if weights.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ngrams = BTreeSet::new();
+    let mut start = 0;
+    while start < weights.len() {
+        let end = (start..weights.len())
+            .rev()
+            .find(|&end| interval_is_sparse(&weights, start, end))
+            .unwrap_or(start);
+        ngrams.insert(chars[start..=end + 1].iter().collect::<String>());
+        start = end + 1;
+    }
+    ngrams.into_iter().map(SparseNgram).collect()
+}
+
+fn interval_is_sparse(weights: &[u32], start: usize, end: usize) -> bool {
+    if end <= start + 1 {
+        return true;
+    }
+
+    let edge_floor = weights[start].min(weights[end]);
+    weights[start + 1..end]
+        .iter()
+        .all(|&interior| edge_floor > interior)
+}
+
+fn pair_weights(chars: &[char]) -> Vec<u32> {
+    chars
+        .windows(2)
+        .map(|pair| pair_weight(pair[0], pair[1]))
+        .collect()
+}
+
+fn pair_weight(left: char, right: char) -> u32 {
+    let mut hash = 0x811c_9dc5_u32;
+    hash = mix_char(hash, left);
+    mix_char(hash, right)
+}
+
+fn mix_char(mut hash: u32, char_: char) -> u32 {
+    hash ^= char_ as u32;
+    hash = hash.wrapping_mul(0x0100_0193);
+    hash ^ (hash >> 16)
+}

--- a/crates/core/src/regex_search/tests.rs
+++ b/crates/core/src/regex_search/tests.rs
@@ -7,7 +7,9 @@ use regex::Regex;
 
 use super::{
     CorpusDocument, MmapRegexPostings, RegexCandidatePlan, RegexCorpus, RegexSearchEngine, Trigram,
-    TrigramIndex, trigrams,
+    TrigramIndex,
+    sparse_ngram::{sparse_covering_ngrams, sparse_ngrams},
+    trigrams,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -185,6 +187,49 @@ fn trigrams_include_punctuation_whitespace_and_preserve_case() {
 }
 
 #[test]
+fn sparse_ngrams_are_deterministic() {
+    let first = sparse_ngram_values("foo_bar_baz");
+    let second = sparse_ngram_values("foo_bar_baz");
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn sparse_ngrams_are_stable_for_code_like_literals() {
+    let ngrams = sparse_ngram_values("MAX_FILE_SIZE");
+
+    assert_eq!(
+        ngrams,
+        [
+            "AX", "AX_", "E_", "E_S", "FI", "FIL", "FILE", "FILE_S", "IL", "ILE", "IZ", "IZE",
+            "LE", "LE_", "LE_S", "MA", "MAX", "SI", "SIZ", "X_", "X_F", "X_FI", "ZE", "_F", "_FI",
+            "_S", "_SI", "_SIZ"
+        ]
+    );
+}
+
+#[test]
+fn sparse_covering_ngrams_use_fewer_query_terms_than_classic_trigrams() {
+    let covering = sparse_covering_ngram_values("MAX_FILE_SIZE");
+
+    assert_eq!(covering, ["E_S", "ILE", "MAX", "SIZ", "X_FI", "ZE"]);
+    assert!(covering.len() < trigrams("MAX_FILE_SIZE").len());
+}
+
+#[test]
+fn sparse_ngrams_return_empty_for_single_character_inputs() {
+    assert!(sparse_ngrams("").is_empty());
+    assert!(sparse_ngrams("a").is_empty());
+}
+
+#[test]
+fn sparse_ngrams_keep_short_bigram_inputs_selective() {
+    let ngrams = sparse_ngram_values("ab");
+
+    assert_eq!(ngrams, ["ab"]);
+}
+
+#[test]
 fn index_maps_every_indexed_doc_id_back_to_path() {
     let first = PathBuf::from("a.rs");
     let second = PathBuf::from("b.rs");
@@ -315,6 +360,48 @@ fn experimental_masks_keep_repeated_overlapping_trigram_matches() {
     let masked_candidates = index.experimental_masked_candidates_for_literal("aaaaa");
 
     assert!(masked_candidates.contains(&index.doc_id(&matching).unwrap()));
+}
+
+#[test]
+fn experimental_sparse_ngram_candidates_are_separate_from_default_candidates() {
+    let matching = PathBuf::from("match.rs");
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "let value = MAX_FILE_SIZE;"),
+        (
+            "classic_false_positive.rs",
+            "MAX AX_ X_F _FI FIL ILE LE_ E_S _SI SIZ IZE",
+        ),
+        ("missing.rs", "let value = MIN_FILE_SIZE;"),
+    ]));
+
+    let classic_candidates = index.candidates_for_literal("MAX_FILE_SIZE");
+    let sparse_candidates = index.experimental_sparse_ngram_candidates_for_literal("MAX_FILE_SIZE");
+
+    assert_eq!(classic_candidates.len(), 2);
+    assert_eq!(sparse_candidates.len(), 1);
+    assert!(sparse_candidates.contains(&index.doc_id(&matching).unwrap()));
+}
+
+#[test]
+fn experimental_sparse_ngram_comparison_reports_query_and_index_costs() {
+    let index = TrigramIndex::with_corpus(TestCorpus::new(&[
+        ("match.rs", "let value = MAX_FILE_SIZE;"),
+        (
+            "classic_false_positive.rs",
+            "MAX AX_ X_F _FI FIL ILE LE_ E_S _SI SIZ IZE",
+        ),
+        ("missing.rs", "let value = MIN_FILE_SIZE;"),
+    ]));
+
+    let comparison = index.experimental_sparse_ngram_comparison_for_literal("MAX_FILE_SIZE");
+
+    assert_eq!(comparison.classic_candidate_count, 2);
+    assert_eq!(comparison.sparse_candidate_count, 1);
+    assert_eq!(comparison.classic_posting_lookups, 11);
+    assert_eq!(comparison.sparse_posting_lookups, 6);
+    assert_eq!(comparison.classic_update_token_count, 11);
+    assert_eq!(comparison.sparse_update_token_count, 28);
+    assert!(comparison.sparse_index_key_count > comparison.classic_index_key_count);
 }
 
 #[test]
@@ -697,6 +784,20 @@ fn write_file(root: &Path, path: &str, content: &str) -> std::io::Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(path, content)
+}
+
+fn sparse_ngram_values(content: &str) -> Vec<String> {
+    sparse_ngrams(content)
+        .iter()
+        .map(|ngram| ngram.0.clone())
+        .collect()
+}
+
+fn sparse_covering_ngram_values(content: &str) -> Vec<String> {
+    sparse_covering_ngrams(content)
+        .iter()
+        .map(|ngram| ngram.0.clone())
+        .collect()
 }
 
 fn plan_trigrams(plan: &RegexCandidatePlan) -> Vec<String> {

--- a/crates/core/src/regex_search/trigram_index.rs
+++ b/crates/core/src/regex_search/trigram_index.rs
@@ -5,9 +5,12 @@ use std::{
 };
 
 use super::{
-    FileSystemCorpus, LiteralSearchResult, MmapRegexPostings, RegexCandidatePlan,
-    RegexCandidateSelection, RegexCorpus, RegexPostingsError, RegexSearchMatch, Trigram,
-    candidate_mask::RegexCandidateMask, line_range_for_match, planner,
+    ExperimentalSparseNgramComparison, FileSystemCorpus, LiteralSearchResult, MmapRegexPostings,
+    RegexCandidatePlan, RegexCandidateSelection, RegexCorpus, RegexPostingsError, RegexSearchMatch,
+    Trigram,
+    candidate_mask::RegexCandidateMask,
+    line_range_for_match, planner,
+    sparse_ngram::{SparseNgram, sparse_covering_ngrams, sparse_ngrams},
 };
 use crate::index::{
     DocId,
@@ -18,6 +21,7 @@ use crate::index::{
 pub struct TrigramIndex<C = FileSystemCorpus> {
     corpus: C,
     postings: HashMap<Trigram, BTreeSet<DocId>>,
+    sparse_postings: HashMap<SparseNgram, BTreeSet<DocId>>,
     masks: RegexCandidateMask,
     documents: DocumentRegistry,
     doc_ids_by_path: Vec<DocId>,
@@ -36,6 +40,7 @@ where
     pub fn with_corpus(corpus: C) -> Self {
         let mut documents = DocumentRegistry::new();
         let mut postings: HashMap<Trigram, BTreeSet<DocId>> = HashMap::new();
+        let mut sparse_postings: HashMap<SparseNgram, BTreeSet<DocId>> = HashMap::new();
         let mut masks = RegexCandidateMask::default();
         let mut corpus_documents = corpus.documents();
         corpus_documents.sort_by(|left, right| left.path.cmp(&right.path));
@@ -44,6 +49,7 @@ where
             insert_document(
                 &mut documents,
                 &mut postings,
+                &mut sparse_postings,
                 &mut masks,
                 document.path.clone(),
                 &document.content,
@@ -55,6 +61,7 @@ where
         Self {
             corpus,
             postings,
+            sparse_postings,
             masks,
             documents,
             doc_ids_by_path,
@@ -88,6 +95,7 @@ where
             let doc_id = insert_document(
                 &mut self.documents,
                 &mut self.postings,
+                &mut self.sparse_postings,
                 &mut self.masks,
                 path.to_path_buf(),
                 &content,
@@ -114,6 +122,11 @@ where
             postings.remove(&metadata.id);
         }
         self.postings.retain(|_, postings| !postings.is_empty());
+        for postings in self.sparse_postings.values_mut() {
+            postings.remove(&metadata.id);
+        }
+        self.sparse_postings
+            .retain(|_, postings| !postings.is_empty());
         self.masks.remove_document(metadata.id);
         Some(metadata.id)
     }
@@ -145,6 +158,32 @@ where
     pub fn experimental_masked_candidates_for_literal(&self, literal: &str) -> BTreeSet<DocId> {
         let plain_candidates = self.candidates_for_literal(literal);
         self.masks.filter_literal(literal, &plain_candidates)
+    }
+
+    pub fn experimental_sparse_ngram_candidates_for_literal(
+        &self,
+        literal: &str,
+    ) -> BTreeSet<DocId> {
+        let query_ngrams = sparse_covering_ngrams(literal);
+        candidates_for_sparse_ngrams(&query_ngrams, &self.sparse_postings, &self.doc_ids_by_path)
+    }
+
+    pub fn experimental_sparse_ngram_comparison_for_literal(
+        &self,
+        literal: &str,
+    ) -> ExperimentalSparseNgramComparison {
+        ExperimentalSparseNgramComparison {
+            classic_candidate_count: self.candidates_for_literal(literal).len(),
+            sparse_candidate_count: self
+                .experimental_sparse_ngram_candidates_for_literal(literal)
+                .len(),
+            classic_posting_lookups: trigrams(literal).len(),
+            sparse_posting_lookups: sparse_covering_ngrams(literal).len(),
+            classic_index_key_count: self.postings.len(),
+            sparse_index_key_count: self.sparse_postings.len(),
+            classic_update_token_count: trigrams(literal).len(),
+            sparse_update_token_count: sparse_ngrams(literal).len(),
+        }
     }
 
     pub fn planned_candidates_for_regex(&self, pattern: &str) -> RegexCandidateSelection {
@@ -200,6 +239,7 @@ where
 fn insert_document(
     documents: &mut DocumentRegistry,
     postings: &mut HashMap<Trigram, BTreeSet<DocId>>,
+    sparse_postings: &mut HashMap<SparseNgram, BTreeSet<DocId>>,
     masks: &mut RegexCandidateMask,
     path: std::path::PathBuf,
     content: &str,
@@ -208,6 +248,9 @@ fn insert_document(
 
     for trigram in trigrams(content) {
         postings.entry(trigram).or_default().insert(doc_id);
+    }
+    for ngram in sparse_ngrams(content) {
+        sparse_postings.entry(ngram).or_default().insert(doc_id);
     }
     masks.add_document(doc_id, content);
 
@@ -236,6 +279,33 @@ pub fn trigrams(content: &str) -> Vec<Trigram> {
 
 fn trigram_count(content: &str) -> usize {
     content.chars().count().saturating_sub(2)
+}
+
+fn candidates_for_sparse_ngrams(
+    query_ngrams: &[SparseNgram],
+    postings: &HashMap<SparseNgram, BTreeSet<DocId>>,
+    all_doc_ids: &[DocId],
+) -> BTreeSet<DocId> {
+    let Some((first, rest)) = query_ngrams.split_first() else {
+        return all_doc_ids.iter().copied().collect();
+    };
+
+    let Some(first_postings) = postings.get(first) else {
+        return BTreeSet::new();
+    };
+
+    let mut candidates = first_postings.clone();
+    for ngram in rest {
+        let Some(next_postings) = postings.get(ngram) else {
+            return BTreeSet::new();
+        };
+        candidates = candidates
+            .intersection(next_postings)
+            .copied()
+            .collect::<BTreeSet<_>>();
+    }
+
+    candidates
 }
 
 fn is_plain_literal_plan(pattern: &str, plan: &RegexCandidatePlan) -> bool {

--- a/crates/core/src/regex_search/types.rs
+++ b/crates/core/src/regex_search/types.rs
@@ -52,6 +52,26 @@ pub struct LiteralSearchResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExperimentalSparseNgramComparison {
+    /// Number of documents selected by the default trigram candidate path.
+    pub classic_candidate_count: usize,
+    /// Number of documents selected by the experimental sparse n-gram path.
+    pub sparse_candidate_count: usize,
+    /// Number of default trigram posting lists read for this literal.
+    pub classic_posting_lookups: usize,
+    /// Number of sparse n-gram posting lists read by the covering query.
+    pub sparse_posting_lookups: usize,
+    /// Number of distinct classic trigram keys in the current index.
+    pub classic_index_key_count: usize,
+    /// Number of distinct sparse n-gram keys in the current experimental index.
+    pub sparse_index_key_count: usize,
+    /// Number of classic trigram tokens emitted if this literal were indexed.
+    pub classic_update_token_count: usize,
+    /// Number of sparse n-gram tokens emitted if this literal were indexed.
+    pub sparse_update_token_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegexCandidateSelection {
     pub candidates: BTreeSet<DocId>,
     pub diagnostics: RegexCandidateDiagnostics,


### PR DESCRIPTION
- add private sparse n-gram generation under `regex_search` with a deterministic in-repo pair-weight function
- keep classic trigram candidate planning as the default path while adding explicit experimental sparse helpers
- expose `ExperimentalSparseNgramComparison` for candidate count, posting lookup, index size, and update-token comparisons
- cover deterministic generation, short-input behavior, and default-versus-experimental candidate separation