### PR TITLE
feat(search): add fielded code search ranking

### DIFF
--- a/crates/cli/src/eval.rs
+++ b/crates/cli/src/eval.rs
@@ -95,8 +95,12 @@ pub(crate) fn evaluate_training(args: &crate::Args, config: &ReaperConfig) -> Re
     let raw_evaluation_data: RawEvaluationData = serde_json::from_str(&file_content)
         .context("failed to deserialize evaluation JSON data")?;
 
-    let evaluation_data = EvaluationData::parse(raw_evaluation_data, config)
-        .context("failed to parse evaluation data")?;
+    let evaluation_data = EvaluationData::parse_with_code_search(
+        raw_evaluation_data,
+        config,
+        args.ranking_algorithm.needs_fielded_index(),
+    )
+    .context("failed to parse evaluation data")?;
 
     let index_root = match &evaluation_data.corpus {
         EvaluationCorpus::Tree { root } => root.clone(),
@@ -126,11 +130,15 @@ pub(crate) fn evaluate_training(args: &crate::Args, config: &ReaperConfig) -> Re
         }
     };
 
-    let inverted_index = InvertedIndex::new(
-        index_root.as_path(),
-        |content: &str| n_gram_transform(content, config),
-        Some(index_root.as_path()),
-    );
+    let inverted_index = if args.ranking_algorithm.needs_fielded_index() {
+        InvertedIndex::new_fielded(index_root.as_path(), config, Some(index_root.as_path()))
+    } else {
+        InvertedIndex::new(
+            index_root.as_path(),
+            |content: &str| n_gram_transform(content, config),
+            Some(index_root.as_path()),
+        )
+    };
 
     let queries = evaluation_data
         .examples

--- a/crates/cli/src/live_search.rs
+++ b/crates/cli/src/live_search.rs
@@ -26,16 +26,22 @@ pub(crate) fn run(
 ) -> Result<()> {
     let config_clone = Arc::clone(&config);
     let transformer = Arc::new(move |content: &str| n_gram_transform(content, &config_clone));
-    let transformer_clone = Arc::clone(&transformer);
     let path_clone = directory.clone();
 
     println!("Indexing files in {}", directory.display());
 
-    let inverted_index = Arc::new(Mutex::new(InvertedIndex::new(
-        directory,
-        transformer_clone.as_ref(),
-        None,
-    )));
+    let inverted_index = if algo.needs_fielded_index() {
+        Arc::new(Mutex::new(InvertedIndex::new_fielded(
+            directory, &config, None,
+        )))
+    } else {
+        let transformer_clone = Arc::clone(&transformer);
+        Arc::new(Mutex::new(InvertedIndex::new(
+            directory,
+            transformer_clone.as_ref(),
+            None,
+        )))
+    };
 
     println!(
         "Successfully indexed {} files",
@@ -45,7 +51,13 @@ pub(crate) fn run(
             .num_docs()
     );
 
-    spawn_watcher(path_clone, Arc::clone(&inverted_index), transformer);
+    spawn_watcher(
+        path_clone,
+        Arc::clone(&inverted_index),
+        transformer,
+        Arc::clone(&config),
+        algo.needs_fielded_index(),
+    );
     run_repl(config, algo, top_n, inverted_index)
 }
 
@@ -55,6 +67,8 @@ fn spawn_watcher(
     transformer: Arc<
         impl Fn(&str) -> HashMap<repo_reaper_core::index::Term, u32> + Send + Sync + 'static,
     >,
+    config: Arc<ReaperConfig>,
+    fielded: bool,
 ) {
     let (tx, rx) = std::sync::mpsc::channel();
     let rx = Arc::new(Mutex::new(rx));
@@ -102,7 +116,11 @@ fn spawn_watcher(
                         };
 
                         for path in &event.paths {
-                            index.update(path, &transformer.as_ref());
+                            if fielded {
+                                index.update_fielded(path, &config);
+                            } else {
+                                index.update(path, &transformer.as_ref());
+                            }
                         }
                     }
                 },
@@ -131,7 +149,11 @@ fn run_repl(
             break;
         }
 
-        let query = AnalyzedQuery::new(&query, &config);
+        let query = if algo.needs_fielded_index() {
+            AnalyzedQuery::new_code_search(&query, &config)
+        } else {
+            AnalyzedQuery::new(&query, &config)
+        };
 
         let ranking = {
             let index = inverted_index

--- a/crates/core/benches/search_bench.rs
+++ b/crates/core/benches/search_bench.rs
@@ -5,7 +5,7 @@ use repo_reaper_core::{
     config::Config,
     index::InvertedIndex,
     query::AnalyzedQuery,
-    ranking::{BM25HyperParams, RankingAlgo},
+    ranking::{BM25FHyperParams, BM25HyperParams, RankingAlgo},
     regex_search::{RegexSearchEngine, TrigramIndex},
     tokenizer::n_gram_transform,
 };
@@ -30,6 +30,10 @@ fn bench_config() -> Config {
 
 fn bm25() -> RankingAlgo {
     RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 })
+}
+
+fn bm25f() -> RankingAlgo {
+    RankingAlgo::BM25F(BM25FHyperParams::code_search_defaults())
 }
 
 fn deterministic_corpus(doc_count: usize, tokens_per_doc: usize, seed: u64) -> Vec<String> {
@@ -114,6 +118,10 @@ fn build_index(root: &Path, config: &Config) -> InvertedIndex {
     )
 }
 
+fn build_fielded_index(root: &Path, config: &Config) -> InvertedIndex {
+    InvertedIndex::new_fielded(root, config, Some(root))
+}
+
 fn bench_tokenization(c: &mut Criterion) {
     let config = bench_config();
     let docs = deterministic_corpus(1, TOKENS_PER_DOC * 8, CORPUS_SEED);
@@ -141,12 +149,17 @@ fn bench_ranked_search(c: &mut Criterion) {
     let config = bench_config();
     let corpus = corpus_fixture();
     let index = build_index(corpus.path(), &config);
+    let fielded_index = build_fielded_index(corpus.path(), &config);
     let query = AnalyzedQuery::new("repository token parser update", &config);
     let bm25 = bm25();
+    let bm25f = bm25f();
 
     let mut group = c.benchmark_group("ranked_search");
     group.bench_function("bm25", |b| {
         b.iter(|| bm25.rank(black_box(&index), black_box(&query), black_box(10)));
+    });
+    group.bench_function("bm25f", |b| {
+        b.iter(|| bm25f.rank(black_box(&fielded_index), black_box(&query), black_box(10)));
     });
     group.bench_function("cosine", |b| {
         b.iter(|| {
@@ -163,16 +176,27 @@ fn bench_search_comparison(c: &mut Criterion) {
     let config = bench_config();
     let corpus = corpus_fixture();
     let ranked_index = build_index(corpus.path(), &config);
+    let fielded_index = build_fielded_index(corpus.path(), &config);
     let regex_index = TrigramIndex::new(corpus.path());
     let regex_engine = RegexSearchEngine::new(corpus.path());
     let ranked_query = AnalyzedQuery::new("repository token parser update", &config);
     let bm25 = bm25();
+    let bm25f = bm25f();
 
     let mut group = c.benchmark_group("search_comparison");
     group.bench_function("traditional_ir/bm25", |b| {
         b.iter(|| {
             bm25.rank(
                 black_box(&ranked_index),
+                black_box(&ranked_query),
+                black_box(10),
+            )
+        });
+    });
+    group.bench_function("traditional_ir/bm25f", |b| {
+        b.iter(|| {
+            bm25f.rank(
+                black_box(&fielded_index),
                 black_box(&ranked_query),
                 black_box(10),
             )

--- a/crates/core/src/evaluation/dataset.rs
+++ b/crates/core/src/evaluation/dataset.rs
@@ -20,12 +20,20 @@ pub struct EvaluationData {
 
 impl EvaluationData {
     pub fn parse(raw: RawEvaluationData, config: &Config) -> Result<Self, EvalError> {
+        Self::parse_with_code_search(raw, config, false)
+    }
+
+    pub fn parse_with_code_search(
+        raw: RawEvaluationData,
+        config: &Config,
+        code_search_queries: bool,
+    ) -> Result<Self, EvalError> {
         let corpus = EvaluationCorpus::parse(raw.local_root, raw.repo, raw.repo_path, raw.commit)?;
 
         let examples: Result<Vec<_>, _> = raw
             .examples
             .into_par_iter()
-            .map(|example| Example::parse(example, config))
+            .map(|example| Example::parse(example, config, code_search_queries))
             .collect();
 
         Ok(EvaluationData {
@@ -85,15 +93,24 @@ pub struct Example {
 }
 
 impl Example {
-    pub fn parse(raw: RawExample, config: &Config) -> Result<Self, EvalError> {
+    pub fn parse(
+        raw: RawExample,
+        config: &Config,
+        code_search_query: bool,
+    ) -> Result<Self, EvalError> {
         let results: Result<Vec<_>, _> = raw
             .results
             .into_par_iter()
             .map(ResultData::try_from)
             .collect();
+        let query = if code_search_query {
+            AnalyzedQuery::new_code_search(&raw.query, config)
+        } else {
+            AnalyzedQuery::new(&raw.query, config)
+        };
 
         Ok(Example {
-            query: AnalyzedQuery::new(&raw.query, config),
+            query,
             narrative: raw.narrative,
             query_shape: raw.query_shape,
             results: results?,

--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -3,6 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::{index::DocumentField, tokenizer::FileType};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DocId(u32);
 
@@ -22,16 +24,42 @@ pub struct DocumentMetadata {
     pub path: PathBuf,
     pub token_length: usize,
     pub file_size_bytes: u64,
+    pub file_type: FileType,
+    pub field_lengths: HashMap<DocumentField, usize>,
 }
 
 impl DocumentMetadata {
     fn new(id: DocId, path: PathBuf, token_length: usize, file_size_bytes: u64) -> Self {
+        Self::new_with_fields(
+            id,
+            path,
+            token_length,
+            file_size_bytes,
+            FileType::UnknownText,
+            HashMap::new(),
+        )
+    }
+
+    fn new_with_fields(
+        id: DocId,
+        path: PathBuf,
+        token_length: usize,
+        file_size_bytes: u64,
+        file_type: FileType,
+        field_lengths: HashMap<DocumentField, usize>,
+    ) -> Self {
         Self {
             id,
             path,
             token_length,
             file_size_bytes,
+            file_type,
+            field_lengths,
         }
+    }
+
+    pub fn field_length(&self, field: DocumentField) -> usize {
+        self.field_lengths.get(&field).copied().unwrap_or(0)
     }
 }
 
@@ -50,6 +78,17 @@ pub trait DocumentCatalog {
         token_length: usize,
         file_size_bytes: u64,
     ) -> DocId;
+    fn insert_or_update_with_fields(
+        &mut self,
+        path: PathBuf,
+        token_length: usize,
+        file_size_bytes: u64,
+        file_type: FileType,
+        field_lengths: HashMap<DocumentField, usize>,
+    ) -> DocId {
+        let _ = (file_type, field_lengths);
+        self.insert_or_update(path, token_length, file_size_bytes)
+    }
     fn remove(&mut self, path: &Path) -> Option<DocumentMetadata>;
     fn get(&self, id: DocId) -> Option<&DocumentMetadata>;
     fn get_by_path(&self, path: &Path) -> Option<&DocumentMetadata>;
@@ -85,6 +124,46 @@ impl DocumentCatalog for DocumentRegistry {
         let id = DocId(self.next_id);
         self.next_id += 1;
         let metadata = DocumentMetadata::new(id, path, token_length, file_size_bytes);
+        self.path_to_id.insert(metadata.path.clone(), id);
+        self.total_token_length += token_length as u64;
+        self.documents.insert(id, metadata);
+        id
+    }
+
+    fn insert_or_update_with_fields(
+        &mut self,
+        path: PathBuf,
+        token_length: usize,
+        file_size_bytes: u64,
+        file_type: FileType,
+        field_lengths: HashMap<DocumentField, usize>,
+    ) -> DocId {
+        if let Some(&id) = self.path_to_id.get(&path) {
+            if let Some(existing) = self.documents.get_mut(&id) {
+                self.total_token_length -= existing.token_length as u64;
+                self.total_token_length += token_length as u64;
+                *existing = DocumentMetadata::new_with_fields(
+                    id,
+                    path,
+                    token_length,
+                    file_size_bytes,
+                    file_type,
+                    field_lengths,
+                );
+            }
+            return id;
+        }
+
+        let id = DocId(self.next_id);
+        self.next_id += 1;
+        let metadata = DocumentMetadata::new_with_fields(
+            id,
+            path,
+            token_length,
+            file_size_bytes,
+            file_type,
+            field_lengths,
+        );
         self.path_to_id.insert(metadata.path.clone(), id);
         self.total_token_length += token_length as u64;
         self.documents.insert(id, metadata);

--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -97,6 +97,7 @@ pub trait DocumentCatalog {
     fn is_empty(&self) -> bool;
     fn total_token_length(&self) -> u64;
     fn avg_doc_length(&self) -> f64;
+    fn avg_field_length(&self, field: DocumentField) -> f64;
 }
 
 impl DocumentRegistry {
@@ -209,6 +210,20 @@ impl DocumentCatalog for DocumentRegistry {
         }
 
         self.total_token_length as f64 / self.documents.len() as f64
+    }
+
+    fn avg_field_length(&self, field: DocumentField) -> f64 {
+        if self.documents.is_empty() {
+            return 0.0;
+        }
+
+        let total = self
+            .documents
+            .values()
+            .map(|metadata| metadata.field_length(field))
+            .sum::<usize>();
+
+        total as f64 / self.documents.len() as f64
     }
 }
 

--- a/crates/core/src/index/field.rs
+++ b/crates/core/src/index/field.rs
@@ -1,0 +1,58 @@
+use std::fmt;
+
+use crate::tokenizer::AnalyzerField;
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+pub enum DocumentField {
+    FileName,
+    RelativePath,
+    Extension,
+    Content,
+    Identifier,
+    Comment,
+    StringLiteral,
+}
+
+impl DocumentField {
+    pub const ALL: [Self; 7] = [
+        Self::FileName,
+        Self::RelativePath,
+        Self::Extension,
+        Self::Content,
+        Self::Identifier,
+        Self::Comment,
+        Self::StringLiteral,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FileName => "filename",
+            Self::RelativePath => "path",
+            Self::Extension => "extension",
+            Self::Content => "content",
+            Self::Identifier => "identifiers",
+            Self::Comment => "comments",
+            Self::StringLiteral => "string_literals",
+        }
+    }
+
+    pub fn analyzer_field(self) -> AnalyzerField {
+        match self {
+            Self::FileName => AnalyzerField::FileName,
+            Self::RelativePath => AnalyzerField::RelativePath,
+            Self::Extension => AnalyzerField::Extension,
+            Self::Content => AnalyzerField::Content,
+            Self::Identifier => AnalyzerField::Identifier,
+            Self::Comment => AnalyzerField::Comment,
+            Self::StringLiteral => AnalyzerField::StringLiteral,
+        }
+    }
+}
+
+impl fmt::Display for DocumentField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -4,18 +4,42 @@ use std::{
 };
 
 use crate::{
+    config::Config,
     index::{
         corpus::{FileSystemIndexCorpus, IndexCorpus, IndexCorpusDocument, SkippedDocument},
         document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry},
+        field::DocumentField,
         term::Term,
     },
     ranking::idf,
+    tokenizer::{AnalyzerProfile, FileType},
 };
 
 #[derive(Debug)]
 pub struct TermDocument {
     pub length: usize,
     pub term_freq: usize,
+    pub field_frequencies: HashMap<DocumentField, usize>,
+    pub field_lengths: HashMap<DocumentField, usize>,
+}
+
+impl TermDocument {
+    pub fn unfielded(length: usize, term_freq: usize) -> Self {
+        Self {
+            length,
+            term_freq,
+            field_frequencies: HashMap::new(),
+            field_lengths: HashMap::new(),
+        }
+    }
+
+    pub fn field_term_freq(&self, field: DocumentField) -> usize {
+        self.field_frequencies.get(&field).copied().unwrap_or(0)
+    }
+
+    pub fn field_length(&self, field: DocumentField) -> usize {
+        self.field_lengths.get(&field).copied().unwrap_or(0)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,8 +87,11 @@ pub struct InvertedIndex<R = DocumentRegistry> {
 struct ProcessedDocument {
     path: PathBuf,
     term_frequencies: HashMap<Term, u32>,
+    field_term_frequencies: HashMap<DocumentField, HashMap<Term, u32>>,
+    field_lengths: HashMap<DocumentField, usize>,
     token_length: usize,
     file_size_bytes: u64,
+    file_type: FileType,
 }
 
 #[cfg(test)]
@@ -92,13 +119,10 @@ impl InvertedIndex<DocumentRegistry> {
                 documents.insert_or_update(PathBuf::from(path), total_len, file_size_bytes);
 
             for &(term, freq) in terms {
-                postings.entry(Term(term.to_string())).or_default().insert(
-                    doc_id,
-                    TermDocument {
-                        length: total_len,
-                        term_freq: freq as usize,
-                    },
-                );
+                postings
+                    .entry(Term(term.to_string()))
+                    .or_default()
+                    .insert(doc_id, TermDocument::unfielded(total_len, freq as usize));
             }
         }
 
@@ -155,6 +179,48 @@ impl InvertedIndex<DocumentRegistry> {
 
         IndexBuildResult { index, report }
     }
+
+    pub fn new_fielded<P>(root: P, config: &Config, drop_prefix: Option<P>) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        Self::build_fielded(root, config, drop_prefix).index
+    }
+
+    pub fn build_fielded<P>(root: P, config: &Config, drop_prefix: Option<P>) -> IndexBuildResult
+    where
+        P: AsRef<Path>,
+    {
+        let corpus = FileSystemIndexCorpus::new(root, drop_prefix);
+        Self::from_corpus_fielded(&corpus, config)
+    }
+
+    pub fn from_corpus_fielded<C>(corpus: &C, config: &Config) -> IndexBuildResult
+    where
+        C: IndexCorpus,
+    {
+        let scan = corpus.scan();
+        let mut registry = DocumentRegistry::new();
+        let mut postings = HashMap::new();
+        for document in &scan.documents {
+            let document = Self::analyze_fielded_document(document, config);
+            Self::insert_processed_document(&mut registry, &mut postings, document);
+        }
+
+        let document_norms = Self::compute_document_norms(&postings, registry.len());
+
+        let index = Self {
+            postings,
+            documents: registry,
+            document_norms,
+        };
+        let report = IndexBuildReport {
+            indexed_document_count: scan.indexed_document_count(),
+            skipped_documents: scan.skipped_documents,
+        };
+
+        IndexBuildResult { index, report }
+    }
 }
 
 impl<R> InvertedIndex<R>
@@ -179,7 +245,13 @@ where
             transform_fn,
         );
         let mut registry = DocumentRegistry::new();
-        let doc_id = registry.insert_or_update(document.path.clone(), document.token_length, 0);
+        let doc_id = registry.insert_or_update_with_fields(
+            document.path.clone(),
+            document.token_length,
+            0,
+            document.file_type,
+            document.field_lengths.clone(),
+        );
         Self::postings_for_document(doc_id, &document)
     }
 
@@ -193,8 +265,57 @@ where
         ProcessedDocument {
             path: document.path.clone(),
             term_frequencies,
+            field_term_frequencies: HashMap::new(),
+            field_lengths: HashMap::new(),
             token_length,
             file_size_bytes: document.file_size_bytes,
+            file_type: FileType::UnknownText,
+        }
+    }
+
+    fn analyze_fielded_document(
+        document: &IndexCorpusDocument,
+        config: &Config,
+    ) -> ProcessedDocument {
+        let file_type = FileType::detect(&document.path);
+        let profile = AnalyzerProfile::for_file_type(file_type);
+        let raw_fields = raw_document_fields(&document.path, &document.content);
+        let mut field_term_frequencies = HashMap::new();
+        let mut field_lengths = HashMap::new();
+        let mut term_frequencies = HashMap::new();
+
+        for field in DocumentField::ALL {
+            let Some(raw_value) = raw_fields.get(&field) else {
+                continue;
+            };
+            let tokens = profile.analyze(field.analyzer_field(), raw_value, config);
+            if tokens.is_empty() {
+                continue;
+            }
+
+            let mut frequencies = HashMap::new();
+            for token in tokens {
+                *frequencies.entry(Term(token)).or_insert(0) += 1;
+            }
+
+            let field_length = frequencies.values().map(|&count| count as usize).sum();
+            field_lengths.insert(field, field_length);
+            for (term, frequency) in &frequencies {
+                *term_frequencies.entry(term.clone()).or_insert(0) += *frequency;
+            }
+            field_term_frequencies.insert(field, frequencies);
+        }
+
+        let token_length = term_frequencies.values().map(|&c| c as usize).sum();
+
+        ProcessedDocument {
+            path: document.path.clone(),
+            term_frequencies,
+            field_term_frequencies,
+            field_lengths,
+            token_length,
+            file_size_bytes: document.file_size_bytes,
+            file_type,
         }
     }
 
@@ -205,11 +326,22 @@ where
         let mut local_map: HashMap<Term, HashMap<DocId, TermDocument>> = HashMap::new();
 
         for (term, freq) in &document.term_frequencies {
+            let field_frequencies = document
+                .field_term_frequencies
+                .iter()
+                .filter_map(|(field, frequencies)| {
+                    frequencies
+                        .get(term)
+                        .map(|frequency| (*field, *frequency as usize))
+                })
+                .collect::<HashMap<_, _>>();
             local_map.entry(term.clone()).or_default().insert(
                 doc_id,
                 TermDocument {
                     length: document.token_length,
                     term_freq: *freq as usize,
+                    field_frequencies,
+                    field_lengths: document.field_lengths.clone(),
                 },
             );
         }
@@ -222,10 +354,12 @@ where
         postings: &mut HashMap<Term, HashMap<DocId, TermDocument>>,
         document: ProcessedDocument,
     ) {
-        let doc_id = registry.insert_or_update(
+        let doc_id = registry.insert_or_update_with_fields(
             document.path.clone(),
             document.token_length,
             document.file_size_bytes,
+            document.file_type,
+            document.field_lengths.clone(),
         );
 
         for (term, doc_map) in Self::postings_for_document(doc_id, &document) {
@@ -329,6 +463,31 @@ where
         }
     }
 
+    pub fn update_fielded(&mut self, path: &Path, config: &Config) {
+        if let Some(doc_id) = self.documents.doc_id(path) {
+            self.remove_postings_for_doc(doc_id);
+        }
+
+        match std::fs::read_to_string(path) {
+            Ok(content) => {
+                let document = Self::analyze_fielded_document(
+                    &IndexCorpusDocument {
+                        path: path.to_path_buf(),
+                        file_size_bytes: content.len() as u64,
+                        content,
+                    },
+                    config,
+                );
+                Self::insert_processed_document(&mut self.documents, &mut self.postings, document);
+                self.rebuild_document_norms();
+            }
+            Err(_) => {
+                self.documents.remove(path);
+                self.rebuild_document_norms();
+            }
+        }
+    }
+
     pub fn remove_document(&mut self, path: &Path) {
         if let Some(metadata) = self.documents.remove(path) {
             self.remove_postings_for_doc(metadata.id);
@@ -370,17 +529,194 @@ where
     }
 }
 
+fn raw_document_fields(path: &Path, content: &str) -> HashMap<DocumentField, String> {
+    let mut fields = HashMap::new();
+
+    if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
+        fields.insert(DocumentField::FileName, file_name.to_string());
+    }
+
+    fields.insert(
+        DocumentField::RelativePath,
+        path.to_string_lossy().into_owned(),
+    );
+
+    if let Some(extension) = path.extension().and_then(|extension| extension.to_str()) {
+        fields.insert(DocumentField::Extension, extension.to_string());
+    }
+
+    fields.insert(DocumentField::Content, content.to_string());
+    fields.insert(
+        DocumentField::Identifier,
+        extract_identifier_lexemes(content).join(" "),
+    );
+    fields.insert(DocumentField::Comment, extract_comments(content).join("\n"));
+    fields.insert(
+        DocumentField::StringLiteral,
+        extract_string_literals(content).join("\n"),
+    );
+
+    fields
+}
+
+fn extract_identifier_lexemes(content: &str) -> Vec<String> {
+    let mut identifiers = Vec::new();
+    let mut current = String::new();
+
+    for character in content.chars() {
+        if character.is_ascii_alphanumeric() || character == '_' || character == '-' {
+            current.push(character);
+            continue;
+        }
+
+        if contains_identifier_signal(&current) {
+            identifiers.push(std::mem::take(&mut current));
+        } else {
+            current.clear();
+        }
+    }
+
+    if contains_identifier_signal(&current) {
+        identifiers.push(current);
+    }
+
+    identifiers
+}
+
+fn contains_identifier_signal(candidate: &str) -> bool {
+    let mut has_lower = false;
+    let mut has_upper = false;
+    let mut has_digit = false;
+
+    for character in candidate.chars() {
+        has_lower |= character.is_ascii_lowercase();
+        has_upper |= character.is_ascii_uppercase();
+        has_digit |= character.is_ascii_digit();
+
+        if character == '_' || character == '-' {
+            return true;
+        }
+    }
+
+    (has_lower && has_upper) || (has_digit && (has_lower || has_upper))
+}
+
+fn extract_comments(content: &str) -> Vec<String> {
+    let mut comments = Vec::new();
+    let mut in_block_comment = false;
+    let mut block_comment = String::new();
+
+    for line in content.lines() {
+        let mut rest = line;
+
+        loop {
+            if in_block_comment {
+                if let Some(end) = rest.find("*/") {
+                    block_comment.push_str(&rest[..end]);
+                    comments.push(std::mem::take(&mut block_comment));
+                    in_block_comment = false;
+                    rest = &rest[end + 2..];
+                    continue;
+                }
+
+                block_comment.push_str(rest);
+                block_comment.push('\n');
+                break;
+            }
+
+            let line_comment = rest.find("//");
+            let hash_comment = rest.find('#');
+            let block_start = rest.find("/*");
+            let comment_start = [line_comment, hash_comment, block_start]
+                .into_iter()
+                .flatten()
+                .min();
+
+            let Some(start) = comment_start else {
+                break;
+            };
+
+            if Some(start) == block_start {
+                rest = &rest[start + 2..];
+                if let Some(end) = rest.find("*/") {
+                    comments.push(rest[..end].to_string());
+                    rest = &rest[end + 2..];
+                    continue;
+                }
+
+                block_comment.push_str(rest);
+                block_comment.push('\n');
+                in_block_comment = true;
+                break;
+            }
+
+            comments.push(rest[start + 1..].to_string());
+            break;
+        }
+    }
+
+    if !block_comment.is_empty() {
+        comments.push(block_comment);
+    }
+
+    comments
+}
+
+fn extract_string_literals(content: &str) -> Vec<String> {
+    let mut literals = Vec::new();
+    let mut literal = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for character in content.chars() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                literal.push(character);
+                escaped = false;
+                continue;
+            }
+
+            if character == '\\' {
+                escaped = true;
+                continue;
+            }
+
+            if character == active_quote {
+                literals.push(std::mem::take(&mut literal));
+                quote = None;
+                continue;
+            }
+
+            literal.push(character);
+            continue;
+        }
+
+        if matches!(character, '"' | '\'' | '`') {
+            quote = Some(character);
+        }
+    }
+
+    literals
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         path::{Path, PathBuf},
     };
 
+    use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+    use rust_stemmers::{Algorithm, Stemmer};
+
     use super::InvertedIndex;
     use crate::{
-        index::{DocId, IndexSkipReason, document_registry::DocumentRegistry, term::Term},
+        config::Config,
+        index::{
+            DocId, DocumentField, IndexSkipReason, document_registry::DocumentRegistry, term::Term,
+        },
         ranking::idf,
+        tokenizer::FileType,
     };
 
     type TestIndex = InvertedIndex<DocumentRegistry>;
@@ -586,6 +922,17 @@ mod tests {
             })
     }
 
+    fn test_config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: Stemmer::create(Algorithm::English),
+            stop_words: stop_words::get(stop_words::LANGUAGE::English)
+                .par_iter()
+                .map(|word| word.to_string())
+                .collect::<HashSet<String>>(),
+        }
+    }
+
     #[test]
     fn new_with_drop_prefix_indexes_files_and_strips_paths() {
         let dir = tempfile::tempdir().unwrap();
@@ -624,6 +971,48 @@ mod tests {
 
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0], &PathBuf::from("a.txt"));
+    }
+
+    #[test]
+    fn fielded_index_tracks_file_type_and_field_lengths() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(
+            dir.path(),
+            "src/inverted_index.rs",
+            "fn parse2Json() { // running parser\nlet value = \"query-id\"; }",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let doc_id = index.doc_id(Path::new("src/inverted_index.rs")).unwrap();
+        let metadata = index.document(doc_id).unwrap();
+
+        assert_eq!(metadata.file_type, FileType::Rust);
+        assert!(metadata.field_length(DocumentField::Content) > 0);
+        assert!(metadata.field_length(DocumentField::Identifier) > 0);
+        assert!(metadata.field_length(DocumentField::Comment) > 0);
+        assert!(metadata.field_length(DocumentField::StringLiteral) > 0);
+    }
+
+    #[test]
+    fn fielded_index_exposes_per_field_term_frequency() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(
+            dir.path(),
+            "src/inverted_index.rs",
+            "fn unrelated() { let value = \"needle\"; }",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let doc_id = index.doc_id(Path::new("src/inverted_index.rs")).unwrap();
+        let term_doc = index
+            .get_postings(&Term("inverted_index".to_string()))
+            .unwrap()
+            .get(&doc_id)
+            .unwrap();
+
+        assert_eq!(term_doc.field_term_freq(DocumentField::FileName), 1);
+        assert_eq!(term_doc.field_term_freq(DocumentField::RelativePath), 1);
+        assert_eq!(term_doc.field_term_freq(DocumentField::Content), 0);
     }
 
     #[test]

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -387,6 +387,10 @@ where
         self.documents.avg_doc_length()
     }
 
+    pub fn avg_field_length(&self, field: DocumentField) -> f64 {
+        self.documents.avg_field_length(field)
+    }
+
     pub fn corpus_stats(&self, high_frequency_limit: usize) -> CorpusStats {
         let mut term_summaries: Vec<TermFrequencySummary> = self
             .postings

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -1,5 +1,6 @@
 pub mod corpus;
 pub mod document_registry;
+pub mod field;
 pub mod inverted_index;
 pub mod term;
 
@@ -8,6 +9,7 @@ pub use corpus::{
     SkippedDocument,
 };
 pub use document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry};
+pub use field::DocumentField;
 pub use inverted_index::{
     CorpusStats, IndexBuildReport, IndexBuildResult, InvertedIndex, TermDocument,
     TermFrequencySummary,

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use crate::{config::Config, index::Term, tokenizer::n_gram_transform};
+use crate::{
+    config::Config,
+    index::Term,
+    tokenizer::{AnalyzerField, AnalyzerProfile, FileType, n_gram_transform},
+};
 
 #[derive(Clone, Debug)]
 pub struct AnalyzedQuery {
@@ -17,6 +21,19 @@ pub struct QueryTerm {
 impl AnalyzedQuery {
     pub fn new(query: &str, config: &Config) -> Self {
         Self::from_frequencies(query.to_string(), n_gram_transform(query, config))
+    }
+
+    pub fn new_code_search(query: &str, config: &Config) -> Self {
+        let profile = AnalyzerProfile::for_file_type(FileType::Rust);
+        let frequencies = profile
+            .analyze(AnalyzerField::Content, query, config)
+            .into_iter()
+            .fold(HashMap::new(), |mut acc, token| {
+                *acc.entry(Term(token)).or_insert(0) += 1;
+                acc
+            });
+
+        Self::from_frequencies(query.to_string(), frequencies)
     }
 
     pub fn from_frequencies(

--- a/crates/core/src/ranking/bm25.rs
+++ b/crates/core/src/ranking/bm25.rs
@@ -49,13 +49,30 @@ impl Scorer for BM25 {
         documents.par_iter().for_each(|(doc_id, term_doc)| {
             let tf = term_doc.term_freq as f64;
             let doc_length = term_doc.length as f64;
-            let score = query_term.weight * idf * (tf * (self.hyper_params.k1 + 1.0))
-                / (tf
-                    + self.hyper_params.k1
-                        * (1.0 - self.hyper_params.b + self.hyper_params.b * doc_length / avgdl));
+            let score = self.score_term(query_term.weight, idf, tf, doc_length, avgdl);
 
             *scores.entry(*doc_id).or_insert(0.0) += score;
         });
+    }
+}
+
+impl BM25 {
+    pub fn score_term(
+        &self,
+        query_weight: f64,
+        idf: f64,
+        tf: f64,
+        doc_length: f64,
+        avgdl: f64,
+    ) -> f64 {
+        if tf == 0.0 || avgdl == 0.0 {
+            return 0.0;
+        }
+
+        query_weight * idf * (tf * (self.hyper_params.k1 + 1.0))
+            / (tf
+                + self.hyper_params.k1
+                    * (1.0 - self.hyper_params.b + self.hyper_params.b * doc_length / avgdl))
     }
 }
 

--- a/crates/core/src/ranking/bm25f.rs
+++ b/crates/core/src/ranking/bm25f.rs
@@ -1,0 +1,206 @@
+use std::collections::HashMap;
+
+use dashmap::DashMap;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+
+use crate::{
+    error::RankingError,
+    index::{DocId, DocumentField, InvertedIndex, Term, TermDocument},
+    query::{AnalyzedQuery, QueryTerm},
+    ranking::{scorer::Scorer, utils::idf},
+};
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct BM25FHyperParams {
+    pub k1: f64,
+    pub b: f64,
+    pub field_weights: HashMap<DocumentField, f64>,
+}
+
+impl BM25FHyperParams {
+    pub fn code_search_defaults() -> Self {
+        Self {
+            k1: 1.2,
+            b: 0.75,
+            field_weights: HashMap::from([
+                (DocumentField::FileName, 8.0),
+                (DocumentField::RelativePath, 4.0),
+                (DocumentField::Extension, 0.25),
+                (DocumentField::Content, 1.0),
+                (DocumentField::Identifier, 3.0),
+                (DocumentField::Comment, 0.8),
+                (DocumentField::StringLiteral, 0.8),
+            ]),
+        }
+    }
+
+    pub fn field_weight(&self, field: DocumentField) -> f64 {
+        self.field_weights.get(&field).copied().unwrap_or(1.0)
+    }
+}
+
+pub fn get_configuration() -> Result<BM25FHyperParams, RankingError> {
+    Ok(BM25FHyperParams::code_search_defaults())
+}
+
+pub struct BM25F {
+    pub hyper_params: BM25FHyperParams,
+}
+
+impl BM25F {
+    pub fn weighted_term_frequency(
+        &self,
+        inverted_index: &InvertedIndex,
+        term_doc: &TermDocument,
+    ) -> f64 {
+        if term_doc.field_frequencies.is_empty() {
+            return term_doc.term_freq as f64;
+        }
+
+        DocumentField::ALL
+            .into_iter()
+            .map(|field| {
+                let tf = term_doc.field_term_freq(field) as f64;
+                if tf == 0.0 {
+                    return 0.0;
+                }
+
+                let field_length = term_doc.field_length(field) as f64;
+                let avg_field_length = inverted_index.avg_field_length(field);
+                if avg_field_length == 0.0 {
+                    return 0.0;
+                }
+
+                let normalized_tf = tf
+                    / (1.0 - self.hyper_params.b
+                        + self.hyper_params.b * field_length / avg_field_length);
+                self.hyper_params.field_weight(field) * normalized_tf
+            })
+            .sum()
+    }
+
+    pub fn score_weighted_tf(&self, query_weight: f64, idf: f64, weighted_tf: f64) -> f64 {
+        if weighted_tf == 0.0 {
+            return 0.0;
+        }
+
+        query_weight * idf * (weighted_tf * (self.hyper_params.k1 + 1.0))
+            / (weighted_tf + self.hyper_params.k1)
+    }
+}
+
+impl Scorer for BM25F {
+    fn score(
+        &self,
+        inverted_index: &InvertedIndex,
+        _: &AnalyzedQuery,
+        _: &Term,
+        query_term: QueryTerm,
+        documents: &HashMap<DocId, TermDocument>,
+        scores: &DashMap<DocId, f64>,
+    ) {
+        let num_docs = inverted_index.num_docs();
+        let idf = idf(num_docs, documents.len());
+
+        documents.par_iter().for_each(|(doc_id, term_doc)| {
+            let weighted_tf = self.weighted_term_frequency(inverted_index, term_doc);
+            let score = self.score_weighted_tf(query_term.weight, idf, weighted_tf);
+
+            *scores.entry(*doc_id).or_insert(0.0) += score;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        path::{Path, PathBuf},
+    };
+
+    use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+    use rust_stemmers::{Algorithm, Stemmer};
+
+    use super::{BM25F, BM25FHyperParams};
+    use crate::{
+        config::Config,
+        index::InvertedIndex,
+        query::AnalyzedQuery,
+        ranking::{BM25HyperParams, RankingAlgo},
+    };
+
+    fn test_config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: Stemmer::create(Algorithm::English),
+            stop_words: stop_words::get(stop_words::LANGUAGE::English)
+                .par_iter()
+                .map(|word| word.to_string())
+                .collect::<HashSet<String>>(),
+        }
+    }
+
+    fn write_temp_file(dir: &Path, name: &str, content: &str) {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn bm25f() -> RankingAlgo {
+        RankingAlgo::BM25F(BM25FHyperParams::code_search_defaults())
+    }
+
+    #[test]
+    fn filename_match_can_outrank_generic_content_match() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "src/inverted_index.rs", "fn unrelated() {}");
+        write_temp_file(
+            dir.path(),
+            "src/generic.rs",
+            "inverted index inverted index inverted index",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let query = AnalyzedQuery::new_code_search("inverted index", &test_config());
+
+        let ranked = bm25f().rank(&index, &query, 2).unwrap().0;
+
+        assert_eq!(ranked[0].doc_path, PathBuf::from("src/inverted_index.rs"));
+    }
+
+    #[test]
+    fn bm25f_keeps_plain_bm25_available_for_comparison() {
+        let index =
+            InvertedIndex::from_documents(&[("a.rs", &[("rust", 3)]), ("b.rs", &[("rust", 1)])]);
+        let query = AnalyzedQuery::new("rust", &test_config());
+
+        let bm25 = RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 })
+            .rank(&index, &query, 2)
+            .unwrap();
+        let bm25f = bm25f().rank(&index, &query, 2).unwrap();
+
+        assert_eq!(bm25.0[0].doc_path, bm25f.0[0].doc_path);
+    }
+
+    #[test]
+    fn weighted_term_frequency_uses_field_weights() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "src/query_id.rs", "fn unrelated() {}");
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let doc_id = index.doc_id(Path::new("src/query_id.rs")).unwrap();
+        let term_doc = index
+            .get_postings(&crate::index::Term("query_id".to_string()))
+            .unwrap()
+            .get(&doc_id)
+            .unwrap();
+        let weighted_tf = BM25F {
+            hyper_params: BM25FHyperParams::code_search_defaults(),
+        }
+        .weighted_term_frequency(&index, term_doc);
+
+        assert!(weighted_tf > term_doc.term_freq as f64);
+    }
+}

--- a/crates/core/src/ranking/explanation.rs
+++ b/crates/core/src/ranking/explanation.rs
@@ -1,0 +1,38 @@
+use crate::index::DocumentField;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoredWithExplanations {
+    pub results: Vec<ScoreWithExplanation>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoreWithExplanation {
+    pub score: super::Score,
+    pub explanation: ScoreExplanation,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoreExplanation {
+    pub final_score: f64,
+    pub terms: Vec<TermExplanation>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TermExplanation {
+    pub term: String,
+    pub query_weight: f64,
+    pub term_frequency: usize,
+    pub document_frequency: usize,
+    pub idf: f64,
+    pub matched_fields: Vec<FieldContribution>,
+    pub contribution: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FieldContribution {
+    pub field: DocumentField,
+    pub term_frequency: usize,
+    pub field_length: usize,
+    pub field_weight: f64,
+    pub contribution: f64,
+}

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -1,4 +1,5 @@
 pub mod bm25;
+pub mod bm25f;
 pub mod cosine_similarity;
 pub mod explanation;
 pub mod scorer;
@@ -6,6 +7,7 @@ pub mod tf_idf;
 mod utils;
 
 pub use bm25::{BM25, BM25HyperParams, get_configuration};
+pub use bm25f::{BM25F, BM25FHyperParams};
 pub use cosine_similarity::CosineSimilarity;
 pub use explanation::{
     FieldContribution, ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations,

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -1,11 +1,16 @@
 pub mod bm25;
 pub mod cosine_similarity;
+pub mod explanation;
 pub mod scorer;
 pub mod tf_idf;
 mod utils;
 
 pub use bm25::{BM25, BM25HyperParams, get_configuration};
 pub use cosine_similarity::CosineSimilarity;
+pub use explanation::{
+    FieldContribution, ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations,
+    TermExplanation,
+};
 pub use scorer::{RankingAlgo, RankingAlgorithm, Score, Scored, Scorer};
 pub use tf_idf::TFIDF;
 pub(crate) use utils::idf;

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -7,9 +7,9 @@ use crate::{
     index::{DocId, DocumentField, InvertedIndex, Term, TermDocument},
     query::{AnalyzedQuery, QueryTerm},
     ranking::{
-        BM25, BM25HyperParams, CosineSimilarity, FieldContribution, ScoreExplanation,
-        ScoreWithExplanation, ScoredWithExplanations, TFIDF, TermExplanation, get_configuration,
-        idf,
+        BM25, BM25F, BM25FHyperParams, BM25HyperParams, CosineSimilarity, FieldContribution,
+        ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations, TFIDF, TermExplanation,
+        get_configuration, idf,
     },
 };
 
@@ -44,6 +44,7 @@ impl std::fmt::Display for Score {
 pub enum RankingAlgo {
     CosineSimilarity,
     BM25(BM25HyperParams),
+    BM25F(BM25FHyperParams),
     TFIDF,
 }
 
@@ -69,6 +70,13 @@ impl RankingAlgorithm for RankingAlgo {
             RankingAlgo::CosineSimilarity => score_with(CosineSimilarity, inverted_index, query),
             RankingAlgo::BM25(hyper_params) => score_with(
                 BM25 {
+                    hyper_params: hyper_params.clone(),
+                },
+                inverted_index,
+                query,
+            ),
+            RankingAlgo::BM25F(hyper_params) => score_with(
+                BM25F {
                     hyper_params: hyper_params.clone(),
                 },
                 inverted_index,
@@ -161,12 +169,19 @@ impl RankingAlgo {
             RankingAlgo::BM25(hyper_params) => {
                 explain_bm25(inverted_index, query, doc_id, hyper_params)
             }
+            RankingAlgo::BM25F(hyper_params) => {
+                explain_bm25f(inverted_index, query, doc_id, hyper_params)
+            }
             RankingAlgo::CosineSimilarity | RankingAlgo::TFIDF => {
                 explain_matched_terms(inverted_index, query, doc_id)
             }
         };
 
         ScoreExplanation { final_score, terms }
+    }
+
+    pub fn needs_fielded_index(&self) -> bool {
+        matches!(self, Self::BM25F(_))
     }
 }
 
@@ -232,7 +247,52 @@ fn explain_matched_terms(
         .collect()
 }
 
+fn explain_bm25f(
+    inverted_index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    doc_id: DocId,
+    hyper_params: &BM25FHyperParams,
+) -> Vec<TermExplanation> {
+    let scorer = BM25F {
+        hyper_params: hyper_params.clone(),
+    };
+    let num_docs = inverted_index.num_docs();
+
+    query
+        .terms()
+        .filter_map(|(term, query_term)| {
+            let documents = inverted_index.get_postings(term)?;
+            let term_doc = documents.get(&doc_id)?;
+            let term_idf = idf(num_docs, documents.len());
+            let weighted_tf = scorer.weighted_term_frequency(inverted_index, term_doc);
+            let contribution = scorer.score_weighted_tf(query_term.weight, term_idf, weighted_tf);
+
+            Some(TermExplanation {
+                term: term.0.clone(),
+                query_weight: query_term.weight,
+                term_frequency: term_doc.term_freq,
+                document_frequency: documents.len(),
+                idf: term_idf,
+                matched_fields: field_contributions_with_weights(
+                    term_doc,
+                    contribution,
+                    &hyper_params.field_weights,
+                ),
+                contribution,
+            })
+        })
+        .collect()
+}
+
 fn field_contributions(term_doc: &TermDocument, contribution: f64) -> Vec<FieldContribution> {
+    field_contributions_with_weights(term_doc, contribution, &HashMap::new())
+}
+
+fn field_contributions_with_weights(
+    term_doc: &TermDocument,
+    contribution: f64,
+    field_weights: &HashMap<DocumentField, f64>,
+) -> Vec<FieldContribution> {
     let mut fields = DocumentField::ALL
         .into_iter()
         .filter_map(|field| {
@@ -251,7 +311,7 @@ fn field_contributions(term_doc: &TermDocument, contribution: f64) -> Vec<FieldC
                 field,
                 term_frequency,
                 field_length: term_doc.field_length(field),
-                field_weight: 1.0,
+                field_weight: field_weights.get(&field).copied().unwrap_or(1.0),
                 contribution: proportional_contribution,
             })
         })
@@ -273,6 +333,7 @@ impl FromStr for RankingAlgo {
 
                 Ok(RankingAlgo::BM25(hyper_params))
             }
+            "bm25f" => Ok(RankingAlgo::BM25F(BM25FHyperParams::code_search_defaults())),
             "tfidf" => Ok(RankingAlgo::TFIDF),
             _ => Err(format!("{} is not a valid ranking algorithm", s)),
         }

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -4,12 +4,16 @@ use dashmap::DashMap;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{DocId, InvertedIndex, Term, TermDocument},
+    index::{DocId, DocumentField, InvertedIndex, Term, TermDocument},
     query::{AnalyzedQuery, QueryTerm},
-    ranking::{BM25, BM25HyperParams, CosineSimilarity, TFIDF, get_configuration},
+    ranking::{
+        BM25, BM25HyperParams, CosineSimilarity, FieldContribution, ScoreExplanation,
+        ScoreWithExplanation, ScoredWithExplanations, TFIDF, TermExplanation, get_configuration,
+        idf,
+    },
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Scored(pub Vec<Score>);
 
 impl std::fmt::Display for Scored {
@@ -24,7 +28,7 @@ impl std::fmt::Display for Scored {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Score {
     pub doc_path: PathBuf,
     pub score: f64,
@@ -123,6 +127,138 @@ impl RankingAlgo {
             Some(Scored(ranking))
         }
     }
+
+    pub fn rank_with_explanations(
+        &self,
+        inverted_index: &InvertedIndex,
+        query: &AnalyzedQuery,
+        top_n: usize,
+    ) -> Option<ScoredWithExplanations> {
+        let ranked = self.rank(inverted_index, query, top_n)?;
+        let results = ranked
+            .0
+            .into_iter()
+            .filter_map(|score| {
+                let doc_id = inverted_index.doc_id(&score.doc_path)?;
+                Some(ScoreWithExplanation {
+                    explanation: self.explain_doc(inverted_index, query, doc_id, score.score),
+                    score,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        Some(ScoredWithExplanations { results })
+    }
+
+    fn explain_doc(
+        &self,
+        inverted_index: &InvertedIndex,
+        query: &AnalyzedQuery,
+        doc_id: DocId,
+        final_score: f64,
+    ) -> ScoreExplanation {
+        let terms = match self {
+            RankingAlgo::BM25(hyper_params) => {
+                explain_bm25(inverted_index, query, doc_id, hyper_params)
+            }
+            RankingAlgo::CosineSimilarity | RankingAlgo::TFIDF => {
+                explain_matched_terms(inverted_index, query, doc_id)
+            }
+        };
+
+        ScoreExplanation { final_score, terms }
+    }
+}
+
+fn explain_bm25(
+    inverted_index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    doc_id: DocId,
+    hyper_params: &BM25HyperParams,
+) -> Vec<TermExplanation> {
+    let scorer = BM25 {
+        hyper_params: hyper_params.clone(),
+    };
+    let avgdl = inverted_index.avg_doc_length();
+    let num_docs = inverted_index.num_docs();
+
+    query
+        .terms()
+        .filter_map(|(term, query_term)| {
+            let documents = inverted_index.get_postings(term)?;
+            let term_doc = documents.get(&doc_id)?;
+            let term_idf = idf(num_docs, documents.len());
+            let contribution = scorer.score_term(
+                query_term.weight,
+                term_idf,
+                term_doc.term_freq as f64,
+                term_doc.length as f64,
+                avgdl,
+            );
+
+            Some(TermExplanation {
+                term: term.0.clone(),
+                query_weight: query_term.weight,
+                term_frequency: term_doc.term_freq,
+                document_frequency: documents.len(),
+                idf: term_idf,
+                matched_fields: field_contributions(term_doc, contribution),
+                contribution,
+            })
+        })
+        .collect()
+}
+
+fn explain_matched_terms(
+    inverted_index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    doc_id: DocId,
+) -> Vec<TermExplanation> {
+    query
+        .terms()
+        .filter_map(|(term, query_term)| {
+            let documents = inverted_index.get_postings(term)?;
+            let term_doc = documents.get(&doc_id)?;
+            Some(TermExplanation {
+                term: term.0.clone(),
+                query_weight: query_term.weight,
+                term_frequency: term_doc.term_freq,
+                document_frequency: documents.len(),
+                idf: idf(inverted_index.num_docs(), documents.len()),
+                matched_fields: field_contributions(term_doc, 0.0),
+                contribution: 0.0,
+            })
+        })
+        .collect()
+}
+
+fn field_contributions(term_doc: &TermDocument, contribution: f64) -> Vec<FieldContribution> {
+    let mut fields = DocumentField::ALL
+        .into_iter()
+        .filter_map(|field| {
+            let term_frequency = term_doc.field_term_freq(field);
+            if term_frequency == 0 {
+                return None;
+            }
+
+            let proportional_contribution = if term_doc.term_freq == 0 {
+                0.0
+            } else {
+                contribution * term_frequency as f64 / term_doc.term_freq as f64
+            };
+
+            Some(FieldContribution {
+                field,
+                term_frequency,
+                field_length: term_doc.field_length(field),
+                field_weight: 1.0,
+                contribution: proportional_contribution,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    fields.sort_by_key(|field| field.field);
+    fields
 }
 
 impl FromStr for RankingAlgo {
@@ -145,11 +281,18 @@ impl FromStr for RankingAlgo {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, path::PathBuf};
+    use std::{
+        collections::{HashMap, HashSet},
+        path::{Path, PathBuf},
+    };
+
+    use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+    use rust_stemmers::{Algorithm, Stemmer};
 
     use super::{BM25HyperParams, RankingAlgo};
     use crate::{
-        index::{InvertedIndex, Term},
+        config::Config,
+        index::{DocumentField, InvertedIndex, Term},
         query::AnalyzedQuery,
     };
 
@@ -172,6 +315,25 @@ mod tests {
 
     fn bm25() -> RankingAlgo {
         RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 })
+    }
+
+    fn test_config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: Stemmer::create(Algorithm::English),
+            stop_words: stop_words::get(stop_words::LANGUAGE::English)
+                .par_iter()
+                .map(|word| word.to_string())
+                .collect::<HashSet<String>>(),
+        }
+    }
+
+    fn write_temp_file(dir: &Path, name: &str, content: &str) {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
     }
 
     #[test]
@@ -204,5 +366,45 @@ mod tests {
 
         assert_eq!(rust_top[0].doc_path, PathBuf::from("rust.rs"));
         assert_eq!(code_top[0].doc_path, PathBuf::from("code.rs"));
+    }
+
+    #[test]
+    fn bm25_explanations_include_terms_fields_and_contributions() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(
+            dir.path(),
+            "src/inverted_index.rs",
+            "fn unrelated() { let value = \"needle\"; }",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let query = AnalyzedQuery::from_weights(
+            "inverted index",
+            HashMap::from([(Term("inverted_index".to_string()), 1.0)]),
+        );
+
+        let explanations = bm25().rank_with_explanations(&index, &query, 1).unwrap();
+        let result = explanations.results.first().unwrap();
+        let term = result.explanation.terms.first().unwrap();
+
+        assert_eq!(
+            result.score.doc_path,
+            PathBuf::from("src/inverted_index.rs")
+        );
+        assert_eq!(term.term, "inverted_index");
+        assert_eq!(term.document_frequency, 1);
+        assert!(term.idf > 0.0);
+        assert!(term.contribution > 0.0);
+        assert!(
+            term.matched_fields
+                .iter()
+                .any(|field| field.field == DocumentField::FileName)
+        );
+        assert!(
+            term.matched_fields
+                .iter()
+                .any(|field| field.field == DocumentField::RelativePath)
+        );
+        assert_eq!(result.explanation.final_score, result.score.score);
     }
 }

--- a/crates/core/src/tokenizer/analyzer.rs
+++ b/crates/core/src/tokenizer/analyzer.rs
@@ -5,7 +5,7 @@ use crate::{
     tokenizer::{content_tokens, tokenize_identifier},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum FileType {
     Rust,
     Python,

--- a/crates/core/src/tokenizer/analyzer.rs
+++ b/crates/core/src/tokenizer/analyzer.rs
@@ -1,0 +1,333 @@
+use std::path::Path;
+
+use crate::{
+    config::Config,
+    tokenizer::{content_tokens, tokenize_identifier},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileType {
+    Rust,
+    Python,
+    JavaScript,
+    TypeScript,
+    Go,
+    Markdown,
+    Toml,
+    Yaml,
+    Json,
+    Shell,
+    UnknownText,
+}
+
+impl FileType {
+    pub fn detect(path: &Path) -> Self {
+        if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
+            match file_name {
+                "Cargo.toml" | "pyproject.toml" => return Self::Toml,
+                "Dockerfile" | "Makefile" | "Justfile" | "justfile" => return Self::Shell,
+                _ => {}
+            }
+        }
+
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some("rs") => Self::Rust,
+            Some("py") => Self::Python,
+            Some("js" | "jsx" | "mjs" | "cjs") => Self::JavaScript,
+            Some("ts" | "tsx" | "mts" | "cts") => Self::TypeScript,
+            Some("go") => Self::Go,
+            Some("md" | "markdown") => Self::Markdown,
+            Some("toml") => Self::Toml,
+            Some("yaml" | "yml") => Self::Yaml,
+            Some("json" | "jsonc") => Self::Json,
+            Some("sh" | "bash" | "zsh" | "fish") => Self::Shell,
+            _ => Self::UnknownText,
+        }
+    }
+
+    fn is_code(self) -> bool {
+        matches!(
+            self,
+            Self::Rust
+                | Self::Python
+                | Self::JavaScript
+                | Self::TypeScript
+                | Self::Go
+                | Self::Shell
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AnalyzerField {
+    FileName,
+    RelativePath,
+    Extension,
+    Content,
+    Identifier,
+    Comment,
+    StringLiteral,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnalyzerProfile {
+    file_type: FileType,
+    exact_fields: FieldAnalyzer,
+    content: FieldAnalyzer,
+    identifier: FieldAnalyzer,
+    comment: FieldAnalyzer,
+    string_literal: FieldAnalyzer,
+}
+
+impl AnalyzerProfile {
+    pub fn for_path(path: &Path) -> Self {
+        Self::for_file_type(FileType::detect(path))
+    }
+
+    pub fn for_file_type(file_type: FileType) -> Self {
+        let exact_fields = FieldAnalyzer::exact_identifier();
+        let identifier = FieldAnalyzer::identifier();
+        let content = if file_type.is_code() {
+            FieldAnalyzer::code_content()
+        } else {
+            FieldAnalyzer::prose()
+        };
+        let comment = if file_type == FileType::Markdown {
+            FieldAnalyzer::prose()
+        } else {
+            FieldAnalyzer::comment()
+        };
+        let string_literal = FieldAnalyzer::string_literal();
+
+        Self {
+            file_type,
+            exact_fields,
+            content,
+            identifier,
+            comment,
+            string_literal,
+        }
+    }
+
+    pub fn file_type(self) -> FileType {
+        self.file_type
+    }
+
+    pub fn analyzer_for(self, field: AnalyzerField) -> FieldAnalyzer {
+        match field {
+            AnalyzerField::FileName | AnalyzerField::RelativePath | AnalyzerField::Extension => {
+                self.exact_fields
+            }
+            AnalyzerField::Content => self.content,
+            AnalyzerField::Identifier => self.identifier,
+            AnalyzerField::Comment => self.comment,
+            AnalyzerField::StringLiteral => self.string_literal,
+        }
+    }
+
+    pub fn analyze(self, field: AnalyzerField, text: &str, config: &Config) -> Vec<String> {
+        self.analyzer_for(field).analyze(text, config)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FieldAnalyzer {
+    split_identifiers: bool,
+    preserve_exact: bool,
+    remove_stop_words: bool,
+    stem: bool,
+}
+
+impl FieldAnalyzer {
+    fn exact_identifier() -> Self {
+        Self {
+            split_identifiers: true,
+            preserve_exact: true,
+            remove_stop_words: false,
+            stem: false,
+        }
+    }
+
+    fn identifier() -> Self {
+        Self {
+            split_identifiers: true,
+            preserve_exact: true,
+            remove_stop_words: false,
+            stem: false,
+        }
+    }
+
+    fn code_content() -> Self {
+        Self {
+            split_identifiers: true,
+            preserve_exact: true,
+            remove_stop_words: false,
+            stem: false,
+        }
+    }
+
+    fn prose() -> Self {
+        Self {
+            split_identifiers: true,
+            preserve_exact: false,
+            remove_stop_words: true,
+            stem: true,
+        }
+    }
+
+    fn comment() -> Self {
+        Self {
+            split_identifiers: true,
+            preserve_exact: false,
+            remove_stop_words: true,
+            stem: true,
+        }
+    }
+
+    fn string_literal() -> Self {
+        Self {
+            split_identifiers: true,
+            preserve_exact: true,
+            remove_stop_words: false,
+            stem: false,
+        }
+    }
+
+    pub fn analyze(self, text: &str, config: &Config) -> Vec<String> {
+        if self == Self::prose() {
+            return content_tokens(text, config);
+        }
+
+        text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '-'))
+            .filter(|lexeme| !lexeme.is_empty())
+            .flat_map(|lexeme| self.analyze_lexeme(lexeme, config))
+            .collect()
+    }
+
+    fn analyze_lexeme(self, lexeme: &str, config: &Config) -> Vec<String> {
+        let Some(identifier) = tokenize_identifier(lexeme) else {
+            return Vec::new();
+        };
+
+        let mut tokens = Vec::new();
+
+        if self.preserve_exact {
+            push_unique(&mut tokens, identifier.exact);
+            push_unique(&mut tokens, identifier.compound);
+        }
+
+        if self.split_identifiers {
+            for part in identifier.parts {
+                if self.remove_stop_words && config.stop_words.contains(&part) {
+                    continue;
+                }
+
+                let token = if self.stem {
+                    config.stemmer.stem(&part).to_string()
+                } else {
+                    part
+                };
+                push_unique(&mut tokens, token);
+            }
+        }
+
+        tokens
+    }
+}
+
+fn push_unique(tokens: &mut Vec<String>, token: String) {
+    if !tokens.iter().any(|existing| existing == &token) {
+        tokens.push(token);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, path::Path};
+
+    use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+    use rust_stemmers::{Algorithm, Stemmer};
+
+    use super::{AnalyzerField, AnalyzerProfile, FileType};
+    use crate::config::Config;
+
+    fn test_config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: Stemmer::create(Algorithm::English),
+            stop_words: stop_words::get(stop_words::LANGUAGE::English)
+                .par_iter()
+                .map(|word| word.to_string())
+                .collect::<HashSet<String>>(),
+        }
+    }
+
+    #[test]
+    fn detects_file_types_from_extensions_and_special_names() {
+        assert_eq!(FileType::detect(Path::new("src/lib.rs")), FileType::Rust);
+        assert_eq!(FileType::detect(Path::new("tool.py")), FileType::Python);
+        assert_eq!(FileType::detect(Path::new("app.jsx")), FileType::JavaScript);
+        assert_eq!(FileType::detect(Path::new("app.tsx")), FileType::TypeScript);
+        assert_eq!(FileType::detect(Path::new("main.go")), FileType::Go);
+        assert_eq!(FileType::detect(Path::new("README.md")), FileType::Markdown);
+        assert_eq!(FileType::detect(Path::new("Cargo.toml")), FileType::Toml);
+        assert_eq!(
+            FileType::detect(Path::new(".github/workflows/ci.yml")),
+            FileType::Yaml
+        );
+        assert_eq!(FileType::detect(Path::new("package.json")), FileType::Json);
+        assert_eq!(
+            FileType::detect(Path::new("scripts/run.sh")),
+            FileType::Shell
+        );
+        assert_eq!(
+            FileType::detect(Path::new("notes.txt")),
+            FileType::UnknownText
+        );
+    }
+
+    #[test]
+    fn markdown_content_uses_prose_analysis_but_rust_content_keeps_code_terms() {
+        let config = test_config();
+        let markdown = AnalyzerProfile::for_file_type(FileType::Markdown).analyze(
+            AnalyzerField::Content,
+            "the running parser",
+            &config,
+        );
+        let rust = AnalyzerProfile::for_file_type(FileType::Rust).analyze(
+            AnalyzerField::Content,
+            "the running parser",
+            &config,
+        );
+
+        assert_eq!(markdown, vec!["run", "parser"]);
+        assert_eq!(rust, vec!["the", "running", "parser"]);
+    }
+
+    #[test]
+    fn exact_code_fields_do_not_stem_or_drop_keywords() {
+        let config = test_config();
+        let tokens = AnalyzerProfile::for_file_type(FileType::Rust).analyze(
+            AnalyzerField::Identifier,
+            "matchRunning",
+            &config,
+        );
+
+        assert_eq!(tokens, vec!["matchrunning", "match", "running"]);
+    }
+
+    #[test]
+    fn filename_and_path_fields_preserve_exact_forms() {
+        let config = test_config();
+        let profile = AnalyzerProfile::for_file_type(FileType::Python);
+
+        assert_eq!(
+            profile.analyze(AnalyzerField::FileName, "repo_reaper.py", &config),
+            vec!["repo_reaper", "reporeaper", "repo", "reaper", "py"]
+        );
+        assert_eq!(
+            profile.analyze(AnalyzerField::RelativePath, "src/query-id.py", &config),
+            vec!["src", "query-id", "queryid", "query", "id", "py"]
+        );
+    }
+}

--- a/crates/core/src/tokenizer/identifier.rs
+++ b/crates/core/src/tokenizer/identifier.rs
@@ -1,0 +1,160 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentifierTokens {
+    pub exact: String,
+    pub compound: String,
+    pub parts: Vec<String>,
+}
+
+pub fn tokenize_identifier(identifier: &str) -> Option<IdentifierTokens> {
+    let exact = identifier.trim().to_lowercase();
+    if exact.is_empty() {
+        return None;
+    }
+
+    let parts = identifier
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '-'))
+        .flat_map(split_identifier_segment)
+        .filter(|part| !part.is_empty())
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>();
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    let compound = parts.join("");
+
+    Some(IdentifierTokens {
+        exact,
+        compound,
+        parts,
+    })
+}
+
+pub fn identifier_token_stream(identifier: &str) -> Vec<String> {
+    let Some(tokens) = tokenize_identifier(identifier) else {
+        return Vec::new();
+    };
+
+    let mut stream = Vec::with_capacity(tokens.parts.len() + 2);
+    push_unique(&mut stream, tokens.exact);
+    push_unique(&mut stream, tokens.compound);
+    for part in tokens.parts {
+        push_unique(&mut stream, part);
+    }
+
+    stream
+}
+
+fn split_identifier_segment(segment: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let chars = segment.char_indices().collect::<Vec<_>>();
+
+    for idx in 1..chars.len() {
+        let previous = chars[idx - 1].1;
+        let current = chars[idx].1;
+        let next = chars.get(idx + 1).map(|(_, c)| *c);
+
+        if previous == '_' || previous == '-' {
+            start = chars[idx].0;
+            continue;
+        }
+
+        if current == '_' || current == '-' {
+            if start < chars[idx].0 {
+                parts.push(&segment[start..chars[idx].0]);
+            }
+            start = chars[idx].0 + current.len_utf8();
+            continue;
+        }
+
+        if is_identifier_boundary(previous, current, next) {
+            parts.push(&segment[start..chars[idx].0]);
+            start = chars[idx].0;
+        }
+    }
+
+    if start < segment.len() {
+        parts.push(&segment[start..]);
+    }
+
+    parts
+}
+
+fn is_identifier_boundary(previous: char, current: char, next: Option<char>) -> bool {
+    if previous.is_ascii_lowercase() && current.is_ascii_uppercase() {
+        return true;
+    }
+
+    if previous.is_ascii_alphabetic() && current.is_ascii_digit() {
+        return true;
+    }
+
+    if previous.is_ascii_digit() && current.is_ascii_alphabetic() {
+        return true;
+    }
+
+    previous.is_ascii_uppercase()
+        && current.is_ascii_uppercase()
+        && next.is_some_and(|next| next.is_ascii_lowercase())
+}
+
+fn push_unique(tokens: &mut Vec<String>, token: String) {
+    if !tokens.iter().any(|existing| existing == &token) {
+        tokens.push(token);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::identifier_token_stream;
+
+    #[test]
+    fn splits_https_connection() {
+        assert_eq!(
+            identifier_token_stream("HTTPSConnection"),
+            vec!["httpsconnection", "https", "connection"]
+        );
+    }
+
+    #[test]
+    fn splits_camel_case() {
+        assert_eq!(
+            identifier_token_stream("camelCase"),
+            vec!["camelcase", "camel", "case"]
+        );
+    }
+
+    #[test]
+    fn preserves_snake_case_exact_form() {
+        assert_eq!(
+            identifier_token_stream("repo_reaper"),
+            vec!["repo_reaper", "reporeaper", "repo", "reaper"]
+        );
+    }
+
+    #[test]
+    fn splits_digits_inside_identifier() {
+        assert_eq!(
+            identifier_token_stream("parse2Json"),
+            vec!["parse2json", "parse", "2", "json"]
+        );
+    }
+
+    #[test]
+    fn splits_acronym_digit_identifier() {
+        assert_eq!(
+            identifier_token_stream("BM25Score"),
+            vec!["bm25score", "bm", "25", "score"]
+        );
+    }
+
+    #[test]
+    fn preserves_kebab_case_exact_form() {
+        assert_eq!(
+            identifier_token_stream("query-id"),
+            vec!["query-id", "queryid", "query", "id"]
+        );
+    }
+}

--- a/crates/core/src/tokenizer/mod.rs
+++ b/crates/core/src/tokenizer/mod.rs
@@ -1,5 +1,7 @@
+pub mod analyzer;
 pub mod identifier;
 pub mod pipeline;
 
+pub use analyzer::{AnalyzerField, AnalyzerProfile, FieldAnalyzer, FileType};
 pub use identifier::{IdentifierTokens, identifier_token_stream, tokenize_identifier};
-pub use pipeline::n_gram_transform;
+pub use pipeline::{content_tokens, n_gram_transform};

--- a/crates/core/src/tokenizer/mod.rs
+++ b/crates/core/src/tokenizer/mod.rs
@@ -1,3 +1,5 @@
+pub mod identifier;
 pub mod pipeline;
 
+pub use identifier::{IdentifierTokens, identifier_token_stream, tokenize_identifier};
 pub use pipeline::n_gram_transform;

--- a/crates/core/src/tokenizer/pipeline.rs
+++ b/crates/core/src/tokenizer/pipeline.rs
@@ -2,16 +2,10 @@ use std::collections::HashMap;
 
 use rayon::{iter::ParallelIterator, slice::ParallelSlice};
 
-use crate::{config::Config, index::Term};
+use crate::{config::Config, index::Term, tokenizer::tokenize_identifier};
 
 pub fn n_gram_transform(content: &str, config: &Config) -> HashMap<Term, u32> {
-    content
-        .to_lowercase()
-        .split(|c: char| !c.is_alphanumeric())
-        .filter(|s| !s.is_empty())
-        .filter(|token| !config.stop_words.contains(*token))
-        .map(|token| config.stemmer.stem(token).to_string())
-        .collect::<Vec<_>>()
+    content_tokens(content, config)
         .par_windows(config.n_grams)
         .map(|window| window.join(" "))
         .map(Term)
@@ -25,6 +19,44 @@ pub fn n_gram_transform(content: &str, config: &Config) -> HashMap<Term, u32> {
             }
             a
         })
+}
+
+pub fn content_tokens(content: &str, config: &Config) -> Vec<String> {
+    content
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '-'))
+        .filter(|s| !s.is_empty())
+        .flat_map(|token| content_tokens_for_lexeme(token, config))
+        .collect()
+}
+
+fn content_tokens_for_lexeme(lexeme: &str, config: &Config) -> Vec<String> {
+    let Some(identifier) = tokenize_identifier(lexeme) else {
+        return Vec::new();
+    };
+
+    let has_identifier_shape = identifier.parts.len() > 1 || lexeme.contains(['_', '-']);
+    let mut tokens = Vec::new();
+
+    if has_identifier_shape {
+        push_unique(&mut tokens, identifier.exact);
+        push_unique(&mut tokens, identifier.compound);
+    }
+
+    for part in identifier.parts {
+        if config.stop_words.contains(&part) {
+            continue;
+        }
+
+        push_unique(&mut tokens, config.stemmer.stem(&part).to_string());
+    }
+
+    tokens
+}
+
+fn push_unique(tokens: &mut Vec<String>, token: String) {
+    if !tokens.iter().any(|existing| existing == &token) {
+        tokens.push(token);
+    }
 }
 
 #[cfg(test)]
@@ -111,5 +143,34 @@ mod tests {
     fn stop_words_excluded_before_frequency_counting() {
         let result = n_gram_transform("the the the quick brown", &test_config(1));
         assert_eq!(result, term_map(&[("quick", 1), ("brown", 1)]));
+    }
+
+    #[test]
+    fn identifiers_emit_split_tokens_and_compounds() {
+        let result = n_gram_transform(
+            "let value = HTTPSConnection::parse2Json();",
+            &test_config(1),
+        );
+
+        assert!(result.contains_key(&Term("httpsconnection".to_string())));
+        assert!(result.contains_key(&Term("https".to_string())));
+        assert!(result.contains_key(&Term("connect".to_string())));
+        assert!(result.contains_key(&Term("parse2json".to_string())));
+        assert!(result.contains_key(&Term("pars".to_string())));
+        assert!(result.contains_key(&Term("2".to_string())));
+        assert!(result.contains_key(&Term("json".to_string())));
+    }
+
+    #[test]
+    fn split_query_terms_match_compound_identifiers() {
+        let document = n_gram_transform("fn repo_reaper() {}", &test_config(1));
+        let query = n_gram_transform("reaper", &test_config(1));
+
+        for term in query.keys() {
+            assert!(
+                document.contains_key(term),
+                "expected document tokens to contain query term {term:?}"
+            );
+        }
     }
 }

--- a/justfile
+++ b/justfile
@@ -55,6 +55,11 @@ audit:
 eval-smoke:
     cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10 --fresh
 
+# run the checked-in repo-native evaluation smoke set with field-aware ranking
+[group("dev")]
+eval-smoke-bm25f:
+    cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10 --fresh --ranking-algorithm bm25f
+
 # compare the checked-in repo-native evaluation set against a saved JSON baseline
 [group("dev")]
 eval-compare baseline:


### PR DESCRIPTION
- add identifier-aware analysis for code-like tokens and preserve exact forms for ranking
- introduce file-type analyzer profiles and a fielded document model for `path`, `filename`, `extension`, `content`, `identifiers`, `comments`, and `string_literals`
- add optional structured ranking explanations for matched terms, matched fields, weights, and score contributions
- implement `bm25f` as a measured field-aware ranking path while keeping existing `bm25` behavior comparable and default