### PR TITLE
feat(search): add positional lexical ranking

### DIFF
--- a/crates/core/benches/search_bench.rs
+++ b/crates/core/benches/search_bench.rs
@@ -5,7 +5,9 @@ use repo_reaper_core::{
     config::Config,
     index::InvertedIndex,
     query::AnalyzedQuery,
-    ranking::{BM25FHyperParams, BM25HyperParams, RankingAlgo},
+    ranking::{
+        BM25FHyperParams, BM25HyperParams, ProximityConfig, QueryLikelihoodParams, RankingAlgo,
+    },
     regex_search::{RegexSearchEngine, TrigramIndex},
     tokenizer::n_gram_transform,
 };
@@ -34,6 +36,17 @@ fn bm25() -> RankingAlgo {
 
 fn bm25f() -> RankingAlgo {
     RankingAlgo::BM25F(BM25FHyperParams::code_search_defaults())
+}
+
+fn bm25_proximity() -> RankingAlgo {
+    RankingAlgo::BM25Proximity(
+        BM25HyperParams { k1: 1.2, b: 0.75 },
+        ProximityConfig::default(),
+    )
+}
+
+fn query_likelihood() -> RankingAlgo {
+    RankingAlgo::QueryLikelihood(QueryLikelihoodParams::dirichlet_defaults())
 }
 
 fn deterministic_corpus(doc_count: usize, tokens_per_doc: usize, seed: u64) -> Vec<String> {
@@ -151,8 +164,11 @@ fn bench_ranked_search(c: &mut Criterion) {
     let index = build_index(corpus.path(), &config);
     let fielded_index = build_fielded_index(corpus.path(), &config);
     let query = AnalyzedQuery::new("repository token parser update", &config);
+    let fielded_query = AnalyzedQuery::new_code_search("repository token parser update", &config);
     let bm25 = bm25();
     let bm25f = bm25f();
+    let bm25_proximity = bm25_proximity();
+    let query_likelihood = query_likelihood();
 
     let mut group = c.benchmark_group("ranked_search");
     group.bench_function("bm25", |b| {
@@ -160,6 +176,18 @@ fn bench_ranked_search(c: &mut Criterion) {
     });
     group.bench_function("bm25f", |b| {
         b.iter(|| bm25f.rank(black_box(&fielded_index), black_box(&query), black_box(10)));
+    });
+    group.bench_function("bm25_proximity", |b| {
+        b.iter(|| {
+            bm25_proximity.rank(
+                black_box(&fielded_index),
+                black_box(&fielded_query),
+                black_box(10),
+            )
+        });
+    });
+    group.bench_function("query_likelihood", |b| {
+        b.iter(|| query_likelihood.rank(black_box(&index), black_box(&query), black_box(10)));
     });
     group.bench_function("cosine", |b| {
         b.iter(|| {
@@ -180,8 +208,11 @@ fn bench_search_comparison(c: &mut Criterion) {
     let regex_index = TrigramIndex::new(corpus.path());
     let regex_engine = RegexSearchEngine::new(corpus.path());
     let ranked_query = AnalyzedQuery::new("repository token parser update", &config);
+    let fielded_query = AnalyzedQuery::new_code_search("repository token parser update", &config);
     let bm25 = bm25();
     let bm25f = bm25f();
+    let bm25_proximity = bm25_proximity();
+    let query_likelihood = query_likelihood();
 
     let mut group = c.benchmark_group("search_comparison");
     group.bench_function("traditional_ir/bm25", |b| {
@@ -197,6 +228,24 @@ fn bench_search_comparison(c: &mut Criterion) {
         b.iter(|| {
             bm25f.rank(
                 black_box(&fielded_index),
+                black_box(&ranked_query),
+                black_box(10),
+            )
+        });
+    });
+    group.bench_function("traditional_ir/bm25_proximity", |b| {
+        b.iter(|| {
+            bm25_proximity.rank(
+                black_box(&fielded_index),
+                black_box(&fielded_query),
+                black_box(10),
+            )
+        });
+    });
+    group.bench_function("traditional_ir/query_likelihood", |b| {
+        b.iter(|| {
+            query_likelihood.rank(
+                black_box(&ranked_index),
                 black_box(&ranked_query),
                 black_box(10),
             )

--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -91,6 +91,7 @@ pub trait DocumentCatalog {
     }
     fn remove(&mut self, path: &Path) -> Option<DocumentMetadata>;
     fn get(&self, id: DocId) -> Option<&DocumentMetadata>;
+    fn iter(&self) -> Box<dyn Iterator<Item = &DocumentMetadata> + '_>;
     fn get_by_path(&self, path: &Path) -> Option<&DocumentMetadata>;
     fn doc_id(&self, path: &Path) -> Option<DocId>;
     fn len(&self) -> usize;
@@ -180,6 +181,10 @@ impl DocumentCatalog for DocumentRegistry {
 
     fn get(&self, id: DocId) -> Option<&DocumentMetadata> {
         self.documents.get(&id)
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = &DocumentMetadata> + '_> {
+        Box::new(self.documents.values())
     }
 
     fn get_by_path(&self, path: &Path) -> Option<&DocumentMetadata> {

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -501,6 +501,20 @@ where
         }
     }
 
+    pub fn total_token_count(&self) -> u64 {
+        self.documents.total_token_length()
+    }
+
+    pub fn vocabulary_size(&self) -> usize {
+        self.postings.len()
+    }
+
+    pub fn collection_frequency(&self, term: &Term) -> usize {
+        self.postings.get(term).map_or(0, |documents| {
+            documents.values().map(|doc| doc.term_freq).sum()
+        })
+    }
+
     pub fn doc_id(&self, path: &Path) -> Option<DocId> {
         self.documents.doc_id(path)
     }

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -21,6 +21,7 @@ pub struct TermDocument {
     pub term_freq: usize,
     pub field_frequencies: HashMap<DocumentField, usize>,
     pub field_lengths: HashMap<DocumentField, usize>,
+    pub field_positions: HashMap<DocumentField, PositionList>,
 }
 
 impl TermDocument {
@@ -30,6 +31,7 @@ impl TermDocument {
             term_freq,
             field_frequencies: HashMap::new(),
             field_lengths: HashMap::new(),
+            field_positions: HashMap::new(),
         }
     }
 
@@ -39,6 +41,49 @@ impl TermDocument {
 
     pub fn field_length(&self, field: DocumentField) -> usize {
         self.field_lengths.get(&field).copied().unwrap_or(0)
+    }
+
+    pub fn field_positions(&self, field: DocumentField) -> Option<&PositionList> {
+        self.field_positions.get(&field)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PositionList {
+    first: u32,
+    gaps: Vec<u32>,
+}
+
+impl PositionList {
+    pub fn from_positions(positions: &[u32]) -> Option<Self> {
+        let (&first, rest) = positions.split_first()?;
+        let gaps = rest
+            .iter()
+            .scan(first, |previous, &position| {
+                let gap = position - *previous;
+                *previous = position;
+                Some(gap)
+            })
+            .collect();
+
+        Some(Self { first, gaps })
+    }
+
+    pub fn positions(&self) -> Vec<u32> {
+        let mut positions = Vec::with_capacity(self.gaps.len() + 1);
+        positions.push(self.first);
+
+        let mut current = self.first;
+        for gap in &self.gaps {
+            current += gap;
+            positions.push(current);
+        }
+
+        positions
+    }
+
+    pub fn gaps(&self) -> &[u32] {
+        &self.gaps
     }
 }
 
@@ -88,6 +133,7 @@ struct ProcessedDocument {
     path: PathBuf,
     term_frequencies: HashMap<Term, u32>,
     field_term_frequencies: HashMap<DocumentField, HashMap<Term, u32>>,
+    field_term_positions: HashMap<DocumentField, HashMap<Term, PositionList>>,
     field_lengths: HashMap<DocumentField, usize>,
     token_length: usize,
     file_size_bytes: u64,
@@ -266,6 +312,7 @@ where
             path: document.path.clone(),
             term_frequencies,
             field_term_frequencies: HashMap::new(),
+            field_term_positions: HashMap::new(),
             field_lengths: HashMap::new(),
             token_length,
             file_size_bytes: document.file_size_bytes,
@@ -281,6 +328,7 @@ where
         let profile = AnalyzerProfile::for_file_type(file_type);
         let raw_fields = raw_document_fields(&document.path, &document.content);
         let mut field_term_frequencies = HashMap::new();
+        let mut field_term_positions = HashMap::new();
         let mut field_lengths = HashMap::new();
         let mut term_frequencies = HashMap::new();
 
@@ -293,9 +341,17 @@ where
                 continue;
             }
 
+            let mut positions: HashMap<Term, Vec<u32>> = HashMap::new();
+            for (position, token) in tokens.iter().enumerate() {
+                positions
+                    .entry(Term(token.clone()))
+                    .or_default()
+                    .push(position as u32);
+            }
+
             let mut frequencies = HashMap::new();
-            for token in tokens {
-                *frequencies.entry(Term(token)).or_insert(0) += 1;
+            for (term, term_positions) in &positions {
+                frequencies.insert(term.clone(), term_positions.len() as u32);
             }
 
             let field_length = frequencies.values().map(|&count| count as usize).sum();
@@ -303,6 +359,15 @@ where
             for (term, frequency) in &frequencies {
                 *term_frequencies.entry(term.clone()).or_insert(0) += *frequency;
             }
+            field_term_positions.insert(
+                field,
+                positions
+                    .into_iter()
+                    .filter_map(|(term, positions)| {
+                        PositionList::from_positions(&positions).map(|list| (term, list))
+                    })
+                    .collect(),
+            );
             field_term_frequencies.insert(field, frequencies);
         }
 
@@ -312,6 +377,7 @@ where
             path: document.path.clone(),
             term_frequencies,
             field_term_frequencies,
+            field_term_positions,
             field_lengths,
             token_length,
             file_size_bytes: document.file_size_bytes,
@@ -335,6 +401,15 @@ where
                         .map(|frequency| (*field, *frequency as usize))
                 })
                 .collect::<HashMap<_, _>>();
+            let field_positions = document
+                .field_term_positions
+                .iter()
+                .filter_map(|(field, positions)| {
+                    positions
+                        .get(term)
+                        .map(|positions| (*field, positions.clone()))
+                })
+                .collect::<HashMap<_, _>>();
             local_map.entry(term.clone()).or_default().insert(
                 doc_id,
                 TermDocument {
@@ -342,6 +417,7 @@ where
                     term_freq: *freq as usize,
                     field_frequencies,
                     field_lengths: document.field_lengths.clone(),
+                    field_positions,
                 },
             );
         }
@@ -431,6 +507,10 @@ where
 
     pub fn document(&self, id: DocId) -> Option<&DocumentMetadata> {
         self.documents.get(id)
+    }
+
+    pub fn documents(&self) -> impl Iterator<Item = &DocumentMetadata> {
+        self.documents.iter()
     }
 
     pub fn doc_freq(&self, term: &Term) -> usize {
@@ -1017,6 +1097,79 @@ mod tests {
         assert_eq!(term_doc.field_term_freq(DocumentField::FileName), 1);
         assert_eq!(term_doc.field_term_freq(DocumentField::RelativePath), 1);
         assert_eq!(term_doc.field_term_freq(DocumentField::Content), 0);
+    }
+
+    #[test]
+    fn fielded_index_stores_positions_per_field_and_as_gaps() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(
+            dir.path(),
+            "src/metrics.rs",
+            "// alpha beta gamma\nfn alpha_beta_gamma() {}",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let doc_id = index.doc_id(Path::new("src/metrics.rs")).unwrap();
+        let alpha = index
+            .get_postings(&Term("alpha".to_string()))
+            .unwrap()
+            .get(&doc_id)
+            .unwrap();
+
+        let content_positions = alpha
+            .field_positions(DocumentField::Content)
+            .unwrap()
+            .positions();
+        let comment_positions = alpha
+            .field_positions(DocumentField::Comment)
+            .unwrap()
+            .positions();
+        let identifier_positions = alpha
+            .field_positions(DocumentField::Identifier)
+            .unwrap()
+            .positions();
+
+        assert_ne!(content_positions, comment_positions);
+        assert_eq!(comment_positions, vec![0]);
+        assert_eq!(identifier_positions, vec![2]);
+        assert_eq!(
+            alpha
+                .field_positions(DocumentField::Content)
+                .unwrap()
+                .gaps(),
+            &[6]
+        );
+    }
+
+    #[test]
+    fn fielded_positions_are_document_local() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "near.rs", "// alpha beta");
+        write_temp_file(dir.path(), "far.rs", "// alpha gap beta");
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let near_doc = index.doc_id(Path::new("near.rs")).unwrap();
+        let far_doc = index.doc_id(Path::new("far.rs")).unwrap();
+        let alpha_docs = index.get_postings(&Term("alpha".to_string())).unwrap();
+
+        assert_eq!(
+            alpha_docs
+                .get(&near_doc)
+                .unwrap()
+                .field_positions(DocumentField::Comment)
+                .unwrap()
+                .positions(),
+            vec![0]
+        );
+        assert_eq!(
+            alpha_docs
+                .get(&far_doc)
+                .unwrap()
+                .field_positions(DocumentField::Comment)
+                .unwrap()
+                .positions(),
+            vec![0]
+        );
     }
 
     #[test]

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -11,7 +11,7 @@ pub use corpus::{
 pub use document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry};
 pub use field::DocumentField;
 pub use inverted_index::{
-    CorpusStats, IndexBuildReport, IndexBuildResult, InvertedIndex, TermDocument,
+    CorpusStats, IndexBuildReport, IndexBuildResult, InvertedIndex, PositionList, TermDocument,
     TermFrequencySummary,
 };
 pub use term::Term;

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -10,6 +10,7 @@ use crate::{
 pub struct AnalyzedQuery {
     original_text: String,
     terms: HashMap<Term, QueryTerm>,
+    phrases: Vec<QueryPhrase>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18,9 +19,26 @@ pub struct QueryTerm {
     pub weight: f64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueryPhrase {
+    pub raw: String,
+    pub terms: Vec<Term>,
+}
+
 impl AnalyzedQuery {
     pub fn new(query: &str, config: &Config) -> Self {
-        Self::from_frequencies(query.to_string(), n_gram_transform(query, config))
+        let phrase_analyzer = |phrase: &str| {
+            content_tokens_for_query(
+                AnalyzerProfile::for_file_type(FileType::UnknownText),
+                phrase,
+                config,
+            )
+        };
+        Self::from_frequencies_and_phrases(
+            query.to_string(),
+            n_gram_transform(query, config),
+            parse_quoted_phrases(query, phrase_analyzer),
+        )
     }
 
     pub fn new_code_search(query: &str, config: &Config) -> Self {
@@ -33,12 +51,26 @@ impl AnalyzedQuery {
                 acc
             });
 
-        Self::from_frequencies(query.to_string(), frequencies)
+        Self::from_frequencies_and_phrases(
+            query.to_string(),
+            frequencies,
+            parse_quoted_phrases(query, |phrase| {
+                content_tokens_for_query(profile, phrase, config)
+            }),
+        )
     }
 
     pub fn from_frequencies(
         original_text: impl Into<String>,
         frequencies: HashMap<Term, u32>,
+    ) -> Self {
+        Self::from_frequencies_and_phrases(original_text, frequencies, Vec::new())
+    }
+
+    pub fn from_frequencies_and_phrases(
+        original_text: impl Into<String>,
+        frequencies: HashMap<Term, u32>,
+        phrases: Vec<QueryPhrase>,
     ) -> Self {
         let terms = frequencies
             .into_iter()
@@ -57,6 +89,7 @@ impl AnalyzedQuery {
         Self {
             original_text: original_text.into(),
             terms,
+            phrases,
         }
     }
 
@@ -78,6 +111,7 @@ impl AnalyzedQuery {
         Self {
             original_text: original_text.into(),
             terms,
+            phrases: Vec::new(),
         }
     }
 
@@ -89,6 +123,10 @@ impl AnalyzedQuery {
         self.terms.iter()
     }
 
+    pub fn phrases(&self) -> &[QueryPhrase] {
+        &self.phrases
+    }
+
     pub fn is_empty(&self) -> bool {
         self.terms.is_empty()
     }
@@ -96,6 +134,39 @@ impl AnalyzedQuery {
     pub fn len(&self) -> usize {
         self.terms.len()
     }
+}
+
+fn parse_quoted_phrases(query: &str, analyzer: impl Fn(&str) -> Vec<String>) -> Vec<QueryPhrase> {
+    let mut phrases = Vec::new();
+    let mut remaining = query;
+
+    while let Some(start) = remaining.find('"') {
+        let after_start = &remaining[start + 1..];
+        let Some(end) = after_start.find('"') else {
+            break;
+        };
+
+        let raw = &after_start[..end];
+        let terms = analyzer(raw).into_iter().map(Term).collect::<Vec<_>>();
+        if terms.len() > 1 {
+            phrases.push(QueryPhrase {
+                raw: raw.to_string(),
+                terms,
+            });
+        }
+
+        remaining = &after_start[end + 1..];
+    }
+
+    phrases
+}
+
+fn content_tokens_for_query(
+    profile: AnalyzerProfile,
+    phrase: &str,
+    config: &Config,
+) -> Vec<String> {
+    profile.analyze(AnalyzerField::Content, phrase, config)
 }
 
 impl std::fmt::Display for AnalyzedQuery {

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -3,6 +3,7 @@ pub mod bm25f;
 pub mod cosine_similarity;
 pub mod explanation;
 pub mod proximity;
+pub mod query_likelihood;
 pub mod scorer;
 pub mod tf_idf;
 mod utils;
@@ -15,6 +16,7 @@ pub use explanation::{
     TermExplanation,
 };
 pub use proximity::ProximityConfig;
+pub use query_likelihood::{QueryLikelihood, QueryLikelihoodParams, QueryLikelihoodSmoothing};
 pub use scorer::{RankingAlgo, RankingAlgorithm, Score, Scored, Scorer};
 pub use tf_idf::TFIDF;
 pub(crate) use utils::idf;

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -2,6 +2,7 @@ pub mod bm25;
 pub mod bm25f;
 pub mod cosine_similarity;
 pub mod explanation;
+pub mod proximity;
 pub mod scorer;
 pub mod tf_idf;
 mod utils;
@@ -13,6 +14,7 @@ pub use explanation::{
     FieldContribution, ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations,
     TermExplanation,
 };
+pub use proximity::ProximityConfig;
 pub use scorer::{RankingAlgo, RankingAlgorithm, Score, Scored, Scorer};
 pub use tf_idf::TFIDF;
 pub(crate) use utils::idf;

--- a/crates/core/src/ranking/proximity.rs
+++ b/crates/core/src/ranking/proximity.rs
@@ -1,0 +1,178 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    index::{DocId, DocumentField, InvertedIndex, Term, TermDocument},
+    query::{AnalyzedQuery, QueryPhrase},
+};
+
+const POSITIONAL_FIELDS: [DocumentField; 4] = [
+    DocumentField::Content,
+    DocumentField::Identifier,
+    DocumentField::Comment,
+    DocumentField::StringLiteral,
+];
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProximityConfig {
+    pub window: u32,
+    pub phrase_boost: f64,
+    pub proximity_boost: f64,
+}
+
+impl Default for ProximityConfig {
+    fn default() -> Self {
+        Self {
+            window: 8,
+            phrase_boost: 2.0,
+            proximity_boost: 0.75,
+        }
+    }
+}
+
+pub fn positional_bonus(
+    index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    doc_id: DocId,
+    config: &ProximityConfig,
+) -> f64 {
+    let phrase_bonus = query
+        .phrases()
+        .iter()
+        .map(|phrase| phrase_match_count(index, doc_id, phrase) as f64 * config.phrase_boost)
+        .sum::<f64>();
+
+    phrase_bonus + proximity_bonus(index, query, doc_id, config)
+}
+
+pub fn phrase_match_count(index: &InvertedIndex, doc_id: DocId, phrase: &QueryPhrase) -> usize {
+    if phrase.terms.len() < 2 {
+        return 0;
+    }
+
+    POSITIONAL_FIELDS
+        .into_iter()
+        .map(|field| phrase_match_count_in_field(index, doc_id, phrase, field))
+        .sum()
+}
+
+fn phrase_match_count_in_field(
+    index: &InvertedIndex,
+    doc_id: DocId,
+    phrase: &QueryPhrase,
+    field: DocumentField,
+) -> usize {
+    let Some(first_doc) = term_doc(index, &phrase.terms[0], doc_id) else {
+        return 0;
+    };
+    let Some(first_positions) = first_doc.field_positions(field) else {
+        return 0;
+    };
+
+    let rest_positions = phrase.terms[1..]
+        .iter()
+        .filter_map(|term| {
+            term_doc(index, term, doc_id)
+                .and_then(|term_doc| term_doc.field_positions(field))
+                .map(|positions| positions.positions())
+        })
+        .collect::<Vec<_>>();
+
+    if rest_positions.len() != phrase.terms.len() - 1 {
+        return 0;
+    }
+
+    first_positions
+        .positions()
+        .into_iter()
+        .filter(|start| {
+            rest_positions
+                .iter()
+                .enumerate()
+                .all(|(offset, positions)| {
+                    positions
+                        .binary_search(&(*start + offset as u32 + 1))
+                        .is_ok()
+                })
+        })
+        .count()
+}
+
+fn proximity_bonus(
+    index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    doc_id: DocId,
+    config: &ProximityConfig,
+) -> f64 {
+    let unique_terms = query
+        .terms()
+        .map(|(term, _)| term.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    if unique_terms.len() < 2 {
+        return 0.0;
+    }
+
+    POSITIONAL_FIELDS
+        .into_iter()
+        .filter_map(|field| minimum_covering_span(index, doc_id, &unique_terms, field))
+        .filter(|span| *span <= config.window)
+        .map(|span| {
+            config.proximity_boost * (config.window - span + 1) as f64 / config.window as f64
+        })
+        .sum()
+}
+
+fn minimum_covering_span(
+    index: &InvertedIndex,
+    doc_id: DocId,
+    terms: &[Term],
+    field: DocumentField,
+) -> Option<u32> {
+    let mut occurrences = Vec::new();
+    for (term_idx, term) in terms.iter().enumerate() {
+        let positions = term_doc(index, term, doc_id)?
+            .field_positions(field)?
+            .positions();
+        for position in positions {
+            occurrences.push((position, term_idx));
+        }
+    }
+
+    occurrences.sort_unstable();
+    let mut counts: HashMap<usize, usize> = HashMap::new();
+    let mut covered_terms = 0;
+    let mut left = 0;
+    let mut best = None;
+
+    for right in 0..occurrences.len() {
+        let right_term = occurrences[right].1;
+        let count = counts.entry(right_term).or_insert(0);
+        if *count == 0 {
+            covered_terms += 1;
+        }
+        *count += 1;
+
+        while covered_terms == terms.len() {
+            let span = occurrences[right].0 - occurrences[left].0;
+            best = Some(best.map_or(span, |current: u32| current.min(span)));
+
+            let left_term = occurrences[left].1;
+            let count = counts
+                .get_mut(&left_term)
+                .expect("left occurrence term should be counted");
+            *count -= 1;
+            if *count == 0 {
+                covered_terms -= 1;
+            }
+            left += 1;
+        }
+    }
+
+    best
+}
+
+fn term_doc<'a>(index: &'a InvertedIndex, term: &Term, doc_id: DocId) -> Option<&'a TermDocument> {
+    index.get_postings(term)?.get(&doc_id)
+}

--- a/crates/core/src/ranking/query_likelihood.rs
+++ b/crates/core/src/ranking/query_likelihood.rs
@@ -1,0 +1,203 @@
+use crate::{
+    index::{DocId, InvertedIndex, Term},
+    query::AnalyzedQuery,
+    ranking::{Score, Scored},
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryLikelihoodParams {
+    pub smoothing: QueryLikelihoodSmoothing,
+}
+
+impl QueryLikelihoodParams {
+    pub fn dirichlet_defaults() -> Self {
+        Self {
+            smoothing: QueryLikelihoodSmoothing::Dirichlet { mu: 1_500.0 },
+        }
+    }
+
+    pub fn jelinek_mercer_defaults() -> Self {
+        Self {
+            smoothing: QueryLikelihoodSmoothing::JelinekMercer { lambda: 0.2 },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryLikelihoodSmoothing {
+    JelinekMercer { lambda: f64 },
+    Dirichlet { mu: f64 },
+}
+
+pub struct QueryLikelihood {
+    pub params: QueryLikelihoodParams,
+}
+
+impl QueryLikelihood {
+    pub fn score(&self, index: &InvertedIndex, query: &AnalyzedQuery) -> Scored {
+        let scores = index
+            .documents()
+            .map(|metadata| Score {
+                doc_path: metadata.path.clone(),
+                score: self.score_doc(index, query, metadata.id),
+            })
+            .collect();
+
+        Scored(scores)
+    }
+
+    fn score_doc(&self, index: &InvertedIndex, query: &AnalyzedQuery, doc_id: DocId) -> f64 {
+        query
+            .terms()
+            .map(|(term, query_term)| {
+                query_term.weight * self.smoothed_term_probability(index, doc_id, term).ln()
+            })
+            .sum()
+    }
+
+    pub fn smoothed_term_probability(
+        &self,
+        index: &InvertedIndex,
+        doc_id: DocId,
+        term: &Term,
+    ) -> f64 {
+        let tf = index
+            .get_postings(term)
+            .and_then(|documents| documents.get(&doc_id))
+            .map_or(0.0, |term_doc| term_doc.term_freq as f64);
+        let doc_len = index
+            .document(doc_id)
+            .map_or(0.0, |metadata| metadata.token_length as f64);
+        let collection_probability = collection_probability(index, term);
+
+        match self.params.smoothing {
+            QueryLikelihoodSmoothing::JelinekMercer { lambda } => {
+                let document_probability = if doc_len == 0.0 { 0.0 } else { tf / doc_len };
+                (1.0 - lambda) * document_probability + lambda * collection_probability
+            }
+            QueryLikelihoodSmoothing::Dirichlet { mu } => {
+                (tf + mu * collection_probability) / (doc_len + mu)
+            }
+        }
+        .max(f64::MIN_POSITIVE)
+    }
+}
+
+fn collection_probability(index: &InvertedIndex, term: &Term) -> f64 {
+    let total_tokens = index.total_token_count() as f64;
+    if total_tokens == 0.0 {
+        return f64::MIN_POSITIVE;
+    }
+
+    let collection_frequency = index.collection_frequency(term) as f64;
+    if collection_frequency > 0.0 {
+        return collection_frequency / total_tokens;
+    }
+
+    1.0 / (total_tokens + index.vocabulary_size() as f64 + 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, path::PathBuf};
+
+    use super::{QueryLikelihood, QueryLikelihoodParams, QueryLikelihoodSmoothing};
+    use crate::{
+        index::{InvertedIndex, Term},
+        query::AnalyzedQuery,
+        ranking::RankingAlgo,
+    };
+
+    fn index() -> InvertedIndex {
+        InvertedIndex::from_documents(&[
+            ("rare.rs", &[("rare", 3), ("common", 1)]),
+            ("common.rs", &[("common", 6)]),
+            ("missing.rs", &[("other", 4)]),
+        ])
+    }
+
+    fn query(term: &str) -> AnalyzedQuery {
+        AnalyzedQuery::from_frequencies(term, HashMap::from([(Term(term.to_string()), 1)]))
+    }
+
+    #[test]
+    fn missing_terms_are_smoothed() {
+        let index = index();
+        let doc_id = index.doc_id(PathBuf::from("rare.rs").as_path()).unwrap();
+        let scorer = QueryLikelihood {
+            params: QueryLikelihoodParams::dirichlet_defaults(),
+        };
+
+        let probability = scorer.smoothed_term_probability(
+            &index,
+            doc_id,
+            &Term("not_in_collection".to_string()),
+        );
+
+        assert!(probability > 0.0);
+    }
+
+    #[test]
+    fn rare_term_ranks_matching_document_first() {
+        let ranking = RankingAlgo::QueryLikelihood(QueryLikelihoodParams::dirichlet_defaults())
+            .rank(&index(), &query("rare"), 3)
+            .unwrap()
+            .0;
+
+        assert_eq!(ranking[0].doc_path, PathBuf::from("rare.rs"));
+    }
+
+    #[test]
+    fn common_term_prefers_document_with_more_common_evidence() {
+        let ranking = RankingAlgo::QueryLikelihood(QueryLikelihoodParams::dirichlet_defaults())
+            .rank(&index(), &query("common"), 3)
+            .unwrap()
+            .0;
+
+        assert_eq!(ranking[0].doc_path, PathBuf::from("common.rs"));
+    }
+
+    #[test]
+    fn jelinek_mercer_lambda_controls_background_smoothing() {
+        let index = index();
+        let doc_id = index.doc_id(PathBuf::from("missing.rs").as_path()).unwrap();
+        let term = Term("rare".to_string());
+        let low_background = QueryLikelihood {
+            params: QueryLikelihoodParams {
+                smoothing: QueryLikelihoodSmoothing::JelinekMercer { lambda: 0.1 },
+            },
+        };
+        let high_background = QueryLikelihood {
+            params: QueryLikelihoodParams {
+                smoothing: QueryLikelihoodSmoothing::JelinekMercer { lambda: 0.9 },
+            },
+        };
+
+        let low = low_background.smoothed_term_probability(&index, doc_id, &term);
+        let high = high_background.smoothed_term_probability(&index, doc_id, &term);
+
+        assert!(high > low);
+    }
+
+    #[test]
+    fn dirichlet_mu_controls_background_smoothing() {
+        let index = index();
+        let doc_id = index.doc_id(PathBuf::from("missing.rs").as_path()).unwrap();
+        let term = Term("rare".to_string());
+        let low_mu = QueryLikelihood {
+            params: QueryLikelihoodParams {
+                smoothing: QueryLikelihoodSmoothing::Dirichlet { mu: 100.0 },
+            },
+        };
+        let high_mu = QueryLikelihood {
+            params: QueryLikelihoodParams {
+                smoothing: QueryLikelihoodSmoothing::Dirichlet { mu: 10_000.0 },
+            },
+        };
+
+        let low = low_mu.smoothed_term_probability(&index, doc_id, &term);
+        let high = high_mu.smoothed_term_probability(&index, doc_id, &term);
+
+        assert!(high > low);
+    }
+}

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -8,8 +8,9 @@ use crate::{
     query::{AnalyzedQuery, QueryTerm},
     ranking::{
         BM25, BM25F, BM25FHyperParams, BM25HyperParams, CosineSimilarity, FieldContribution,
-        ProximityConfig, ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations, TFIDF,
-        TermExplanation, get_configuration, idf,
+        ProximityConfig, QueryLikelihood, QueryLikelihoodParams, ScoreExplanation,
+        ScoreWithExplanation, ScoredWithExplanations, TFIDF, TermExplanation, get_configuration,
+        idf,
     },
 };
 
@@ -46,6 +47,7 @@ pub enum RankingAlgo {
     BM25(BM25HyperParams),
     BM25F(BM25FHyperParams),
     BM25Proximity(BM25HyperParams, ProximityConfig),
+    QueryLikelihood(QueryLikelihoodParams),
     TFIDF,
 }
 
@@ -103,6 +105,10 @@ impl RankingAlgorithm for RankingAlgo {
                 }
                 scored
             }
+            RankingAlgo::QueryLikelihood(params) => QueryLikelihood {
+                params: params.clone(),
+            }
+            .score(inverted_index, query),
             RankingAlgo::TFIDF => score_with(TFIDF, inverted_index, query),
         }
     }
@@ -200,9 +206,9 @@ impl RankingAlgo {
             RankingAlgo::BM25Proximity(hyper_params, _) => {
                 explain_bm25(inverted_index, query, doc_id, hyper_params)
             }
-            RankingAlgo::CosineSimilarity | RankingAlgo::TFIDF => {
-                explain_matched_terms(inverted_index, query, doc_id)
-            }
+            RankingAlgo::CosineSimilarity
+            | RankingAlgo::QueryLikelihood(_)
+            | RankingAlgo::TFIDF => explain_matched_terms(inverted_index, query, doc_id),
         };
 
         ScoreExplanation { final_score, terms }
@@ -371,6 +377,12 @@ impl FromStr for RankingAlgo {
                     ProximityConfig::default(),
                 ))
             }
+            "ql" | "ql-dirichlet" | "query-likelihood" => Ok(RankingAlgo::QueryLikelihood(
+                QueryLikelihoodParams::dirichlet_defaults(),
+            )),
+            "ql-jm" | "jelinek-mercer" => Ok(RankingAlgo::QueryLikelihood(
+                QueryLikelihoodParams::jelinek_mercer_defaults(),
+            )),
             "tfidf" => Ok(RankingAlgo::TFIDF),
             _ => Err(format!("{} is not a valid ranking algorithm", s)),
         }

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -8,8 +8,8 @@ use crate::{
     query::{AnalyzedQuery, QueryTerm},
     ranking::{
         BM25, BM25F, BM25FHyperParams, BM25HyperParams, CosineSimilarity, FieldContribution,
-        ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations, TFIDF, TermExplanation,
-        get_configuration, idf,
+        ProximityConfig, ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations, TFIDF,
+        TermExplanation, get_configuration, idf,
     },
 };
 
@@ -45,6 +45,7 @@ pub enum RankingAlgo {
     CosineSimilarity,
     BM25(BM25HyperParams),
     BM25F(BM25FHyperParams),
+    BM25Proximity(BM25HyperParams, ProximityConfig),
     TFIDF,
 }
 
@@ -82,6 +83,26 @@ impl RankingAlgorithm for RankingAlgo {
                 inverted_index,
                 query,
             ),
+            RankingAlgo::BM25Proximity(hyper_params, config) => {
+                let mut scored = score_with(
+                    BM25 {
+                        hyper_params: hyper_params.clone(),
+                    },
+                    inverted_index,
+                    query,
+                );
+                for score in &mut scored.0 {
+                    if let Some(doc_id) = inverted_index.doc_id(&score.doc_path) {
+                        score.score += crate::ranking::proximity::positional_bonus(
+                            inverted_index,
+                            query,
+                            doc_id,
+                            config,
+                        );
+                    }
+                }
+                scored
+            }
             RankingAlgo::TFIDF => score_with(TFIDF, inverted_index, query),
         }
     }
@@ -126,7 +147,11 @@ impl RankingAlgo {
 
         let mut ranking = self.score(inverted_index, query).0;
 
-        ranking.sort_by(|a, b| b.score.total_cmp(&a.score));
+        ranking.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.doc_path.cmp(&b.doc_path))
+        });
         ranking.truncate(top_n);
 
         if ranking.is_empty() {
@@ -172,6 +197,9 @@ impl RankingAlgo {
             RankingAlgo::BM25F(hyper_params) => {
                 explain_bm25f(inverted_index, query, doc_id, hyper_params)
             }
+            RankingAlgo::BM25Proximity(hyper_params, _) => {
+                explain_bm25(inverted_index, query, doc_id, hyper_params)
+            }
             RankingAlgo::CosineSimilarity | RankingAlgo::TFIDF => {
                 explain_matched_terms(inverted_index, query, doc_id)
             }
@@ -181,7 +209,7 @@ impl RankingAlgo {
     }
 
     pub fn needs_fielded_index(&self) -> bool {
-        matches!(self, Self::BM25F(_))
+        matches!(self, Self::BM25F(_) | Self::BM25Proximity(_, _))
     }
 }
 
@@ -334,6 +362,15 @@ impl FromStr for RankingAlgo {
                 Ok(RankingAlgo::BM25(hyper_params))
             }
             "bm25f" => Ok(RankingAlgo::BM25F(BM25FHyperParams::code_search_defaults())),
+            "bm25-proximity" | "proximity" => {
+                let hyper_params =
+                    get_configuration().map_err(|e| format!("failed to load BM25 config: {e}"))?;
+
+                Ok(RankingAlgo::BM25Proximity(
+                    hyper_params,
+                    ProximityConfig::default(),
+                ))
+            }
             "tfidf" => Ok(RankingAlgo::TFIDF),
             _ => Err(format!("{} is not a valid ranking algorithm", s)),
         }
@@ -350,7 +387,7 @@ mod tests {
     use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
     use rust_stemmers::{Algorithm, Stemmer};
 
-    use super::{BM25HyperParams, RankingAlgo};
+    use super::{BM25HyperParams, ProximityConfig, RankingAlgo};
     use crate::{
         config::Config,
         index::{DocumentField, InvertedIndex, Term},
@@ -467,5 +504,73 @@ mod tests {
                 .any(|field| field.field == DocumentField::RelativePath)
         );
         assert_eq!(result.explanation.final_score, result.score.score);
+    }
+
+    #[test]
+    fn quoted_phrase_requires_adjacent_terms_in_one_field() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "phrase.rs", "// mean average precision");
+        write_temp_file(dir.path(), "split.rs", "// mean average\nfn precision() {}");
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let query = AnalyzedQuery::new_code_search("\"mean average precision\"", &test_config());
+        let phrase = query.phrases().first().unwrap();
+
+        let phrase_doc = index.doc_id(Path::new("phrase.rs")).unwrap();
+        let split_doc = index.doc_id(Path::new("split.rs")).unwrap();
+
+        assert_eq!(
+            crate::ranking::proximity::phrase_match_count(&index, phrase_doc, phrase),
+            1
+        );
+        assert_eq!(
+            crate::ranking::proximity::phrase_match_count(&index, split_doc, phrase),
+            0
+        );
+    }
+
+    #[test]
+    fn proximity_score_promotes_near_terms_over_far_terms() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "near.rs", "// alpha beta gamma");
+        write_temp_file(
+            dir.path(),
+            "far.rs",
+            "// alpha filler filler filler filler filler filler beta gamma",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let query = AnalyzedQuery::new_code_search("alpha gamma", &test_config());
+        let ranking = RankingAlgo::BM25Proximity(
+            BM25HyperParams { k1: 1.2, b: 0.75 },
+            ProximityConfig {
+                window: 4,
+                phrase_boost: 0.0,
+                proximity_boost: 10.0,
+            },
+        )
+        .rank(&index, &query, 2)
+        .unwrap()
+        .0;
+
+        assert_eq!(ranking[0].doc_path, PathBuf::from("near.rs"));
+    }
+
+    #[test]
+    fn phrase_matching_does_not_cross_documents() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "alpha.rs", "// alpha");
+        write_temp_file(dir.path(), "beta.rs", "// beta");
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let query = AnalyzedQuery::new_code_search("\"alpha beta\"", &test_config());
+        let phrase = query.phrases().first().unwrap();
+
+        for metadata in index.documents() {
+            assert_eq!(
+                crate::ranking::proximity::phrase_match_count(&index, metadata.id, phrase),
+                0
+            );
+        }
     }
 }

--- a/justfile
+++ b/justfile
@@ -60,6 +60,11 @@ eval-smoke:
 eval-smoke-bm25f:
     cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10 --fresh --ranking-algorithm bm25f
 
+# run the checked-in repo-native evaluation smoke set with query likelihood ranking
+[group("dev")]
+eval-smoke-ql:
+    cargo run -p repo-reaper-cli -- --evaluate --eval-data ./data/eval/repo_reaper.json --eval-format pretty --top-n 10 --fresh --ranking-algorithm ql-dirichlet
+
 # compare the checked-in repo-native evaluation set against a saved JSON baseline
 [group("dev")]
 eval-compare baseline:


### PR DESCRIPTION
- add field-aware positional postings for ranked lexical search while preserving existing `bm25` and `bm25f` ranking paths
- introduce quoted phrase matching and a non-default `bm25-proximity` ranking mode so nearby terms can use token positions without changing the default search behavior
- add `query-likelihood` ranking with `jelinek-mercer` and `dirichlet` smoothing as measured alternatives to `bm25`
- extend `just eval-smoke-ql` and `search_bench` coverage so reviewers can compare lexical ranking models before promoting a new default