### PR TITLE
feat(search): add persistent index architecture

### DIFF
--- a/crates/cli/src/live_search.rs
+++ b/crates/cli/src/live_search.rs
@@ -7,15 +7,23 @@ use std::{
     thread,
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use chrono::Utc;
 use notify::{
     Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
     event::{ModifyKind, RemoveKind},
 };
 use repo_reaper_core::{
-    config::Config as ReaperConfig, index::InvertedIndex, query::AnalyzedQuery,
-    ranking::RankingAlgo, tokenizer::n_gram_transform,
+    config::Config as ReaperConfig,
+    index::{
+        InvertedIndex, SearchEngine,
+        event_log::{IndexEvent, append_event, clear_events, read_events, replay_events},
+        inverted_file::InvertedFileLayout,
+        snapshot::{load_snapshot, write_snapshot},
+    },
+    query::AnalyzedQuery,
+    ranking::RankingAlgo,
+    tokenizer::n_gram_transform,
 };
 
 pub(crate) fn run(
@@ -23,6 +31,8 @@ pub(crate) fn run(
     config: Arc<ReaperConfig>,
     algo: RankingAlgo,
     top_n: usize,
+    index_dir: Option<PathBuf>,
+    reindex: bool,
 ) -> Result<()> {
     let config_clone = Arc::clone(&config);
     let transformer = Arc::new(move |content: &str| n_gram_transform(content, &config_clone));
@@ -30,45 +40,69 @@ pub(crate) fn run(
 
     println!("Indexing files in {}", directory.display());
 
-    let inverted_index = if algo.needs_fielded_index() {
-        Arc::new(Mutex::new(InvertedIndex::new_fielded(
-            directory, &config, None,
-        )))
+    let fielded = algo.needs_fielded_index();
+    let index = if let Some(index_dir) = index_dir.as_ref().filter(|_| !reindex) {
+        match load_snapshot(index_dir, &directory, &config) {
+            Ok(mut index) => {
+                let events = read_events(index_dir).context("failed to read index event log")?;
+                replay_events(&mut index, &events, transformer.as_ref(), &config, fielded);
+                index
+            }
+            Err(error) => {
+                eprintln!("rebuilding index because snapshot could not be loaded: {error}");
+                build_index(&directory, &config, transformer.as_ref(), fielded)
+            }
+        }
     } else {
-        let transformer_clone = Arc::clone(&transformer);
-        Arc::new(Mutex::new(InvertedIndex::new(
-            directory,
-            transformer_clone.as_ref(),
-            None,
-        )))
+        build_index(&directory, &config, transformer.as_ref(), fielded)
     };
 
-    println!(
-        "Successfully indexed {} files",
-        inverted_index
-            .lock()
-            .map_err(|_| anyhow!("index lock poisoned"))?
-            .num_docs()
-    );
+    let engine = SearchEngine::new(index);
+
+    if let Some(index_dir) = &index_dir {
+        engine.with_read(|index| {
+            write_snapshot(index, index_dir, &directory, &config)?;
+            InvertedFileLayout::write(index, index_dir)?;
+            clear_events(index_dir)?;
+            Ok::<_, anyhow::Error>(())
+        })??;
+    }
+
+    println!("Successfully indexed {} files", engine.num_docs()?);
 
     spawn_watcher(
         path_clone,
-        Arc::clone(&inverted_index),
+        engine.clone(),
         transformer,
         Arc::clone(&config),
-        algo.needs_fielded_index(),
+        fielded,
+        index_dir,
     );
-    run_repl(config, algo, top_n, inverted_index)
+    run_repl(config, algo, top_n, engine)
+}
+
+fn build_index(
+    directory: &PathBuf,
+    config: &ReaperConfig,
+    transformer: &(impl Fn(&str) -> HashMap<repo_reaper_core::index::Term, u32> + Sync),
+    fielded: bool,
+) -> InvertedIndex {
+    if fielded {
+        InvertedIndex::new_fielded(directory, config, None)
+    } else {
+        InvertedIndex::new(directory, transformer, None)
+    }
 }
 
 fn spawn_watcher(
     path: PathBuf,
-    inverted_index: Arc<Mutex<InvertedIndex>>,
+    engine: SearchEngine,
     transformer: Arc<
         impl Fn(&str) -> HashMap<repo_reaper_core::index::Term, u32> + Send + Sync + 'static,
     >,
     config: Arc<ReaperConfig>,
     fielded: bool,
+    index_dir: Option<PathBuf>,
 ) {
     let (tx, rx) = std::sync::mpsc::channel();
     let rx = Arc::new(Mutex::new(rx));
@@ -100,26 +134,40 @@ fn spawn_watcher(
                 Ok(Ok(event)) => match event.kind {
                     EventKind::Modify(ModifyKind::Metadata(_)) => continue,
                     EventKind::Remove(RemoveKind::File | RemoveKind::Any) => {
-                        let Ok(mut index) = inverted_index.lock() else {
-                            eprintln!("watch error: index lock poisoned");
-                            return;
-                        };
-
                         for path in &event.paths {
-                            index.remove_document(path);
+                            let event = IndexEvent::FileDeleted { path: path.clone() };
+                            if let Some(index_dir) = &index_dir
+                                && let Err(error) = append_event(index_dir, &event)
+                            {
+                                eprintln!("watch error: failed to append index event: {error}");
+                                return;
+                            }
+                            if let Err(error) =
+                                engine.apply_event(&event, transformer.as_ref(), &config, fielded)
+                            {
+                                eprintln!("watch error: {error}");
+                                return;
+                            }
                         }
                     }
                     _ => {
-                        let Ok(mut index) = inverted_index.lock() else {
-                            eprintln!("watch error: index lock poisoned");
-                            return;
-                        };
-
                         for path in &event.paths {
-                            if fielded {
-                                index.update_fielded(path, &config);
+                            let event = if path.exists() {
+                                IndexEvent::FileModified { path: path.clone() }
                             } else {
-                                index.update(path, &transformer.as_ref());
+                                IndexEvent::FileDeleted { path: path.clone() }
+                            };
+                            if let Some(index_dir) = &index_dir
+                                && let Err(error) = append_event(index_dir, &event)
+                            {
+                                eprintln!("watch error: failed to append index event: {error}");
+                                return;
+                            }
+                            if let Err(error) =
+                                engine.apply_event(&event, transformer.as_ref(), &config, fielded)
+                            {
+                                eprintln!("watch error: {error}");
+                                return;
                             }
                         }
                     }
@@ -135,7 +183,7 @@ fn run_repl(
     config: Arc<ReaperConfig>,
     algo: RankingAlgo,
     top_n: usize,
-    inverted_index: Arc<Mutex<InvertedIndex>>,
+    engine: SearchEngine,
 ) -> Result<()> {
     loop {
         println!("Enter a query: ");
@@ -155,12 +203,7 @@ fn run_repl(
             AnalyzedQuery::new(&query, &config)
         };
 
-        let ranking = {
-            let index = inverted_index
-                .lock()
-                .map_err(|_| anyhow!("index lock poisoned"))?;
-            algo.rank(&index, &query, top_n)
-        };
+        let ranking = engine.search(&algo, &query, top_n)?;
 
         log_query(&query, &ranking, &algo, top_n)?;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -59,6 +59,12 @@ struct Args {
     /// Print corpus statistics for the indexed directory and exit
     #[clap(long, default_value = "false")]
     stats: bool,
+    /// Directory for ranked index snapshots and update event logs
+    #[clap(long)]
+    index_dir: Option<PathBuf>,
+    /// Rebuild the ranked index even when a compatible snapshot exists
+    #[clap(long, default_value = "false")]
+    reindex: bool,
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -99,7 +105,14 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    live_search::run(args.directory, config, args.ranking_algorithm, args.top_n)
+    live_search::run(
+        args.directory,
+        config,
+        args.ranking_algorithm,
+        args.top_n,
+        args.index_dir,
+        args.reindex,
+    )
 }
 
 fn print_directory_stats(directory: &Path, config: &ReaperConfig) {

--- a/crates/core/src/index/compression.rs
+++ b/crates/core/src/index/compression.rs
@@ -1,0 +1,196 @@
+use crate::index::DocId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompressedPostingList {
+    bytes: Vec<u8>,
+    doc_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedPosting {
+    pub doc_id: DocId,
+    pub term_freq: u32,
+    pub positions: Vec<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CompressionError {
+    #[error("compressed posting list ended unexpectedly")]
+    UnexpectedEof,
+    #[error("compressed integer is too large")]
+    IntegerOverflow,
+    #[error("posting list doc ids are not sorted")]
+    UnsortedDocIds,
+    #[error("posting positions are not sorted")]
+    UnsortedPositions,
+    #[error("decoded posting gap overflowed")]
+    GapOverflow,
+}
+
+impl CompressedPostingList {
+    pub fn from_postings(postings: &[DecodedPosting]) -> Result<Self, CompressionError> {
+        let mut bytes = Vec::new();
+        let mut previous_doc = 0;
+
+        for posting in postings {
+            let doc = posting.doc_id.as_u32();
+            if doc < previous_doc {
+                return Err(CompressionError::UnsortedDocIds);
+            }
+
+            encode_u32(doc - previous_doc, &mut bytes);
+            encode_u32(posting.term_freq, &mut bytes);
+            encode_u32(posting.positions.len() as u32, &mut bytes);
+
+            let mut previous_position = 0;
+            for &position in &posting.positions {
+                if position < previous_position {
+                    return Err(CompressionError::UnsortedPositions);
+                }
+                encode_u32(position - previous_position, &mut bytes);
+                previous_position = position;
+            }
+
+            previous_doc = doc;
+        }
+
+        Ok(Self {
+            bytes,
+            doc_count: postings.len(),
+        })
+    }
+
+    pub fn decode(&self) -> Result<Vec<DecodedPosting>, CompressionError> {
+        decode_postings(&self.bytes, self.doc_count)
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn doc_count(&self) -> usize {
+        self.doc_count
+    }
+}
+
+pub fn encode_u32(mut value: u32, out: &mut Vec<u8>) {
+    while value >= 0x80 {
+        out.push((value as u8 & 0x7f) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}
+
+pub fn decode_u32(bytes: &[u8], offset: &mut usize) -> Result<u32, CompressionError> {
+    let mut value = 0u32;
+    let mut shift = 0;
+
+    loop {
+        let byte = *bytes.get(*offset).ok_or(CompressionError::UnexpectedEof)?;
+        *offset += 1;
+
+        if shift >= 32 && byte != 0 {
+            return Err(CompressionError::IntegerOverflow);
+        }
+
+        value |= ((byte & 0x7f) as u32)
+            .checked_shl(shift)
+            .ok_or(CompressionError::IntegerOverflow)?;
+
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+
+        shift += 7;
+        if shift > 35 {
+            return Err(CompressionError::IntegerOverflow);
+        }
+    }
+}
+
+pub fn decode_postings(
+    bytes: &[u8],
+    doc_count: usize,
+) -> Result<Vec<DecodedPosting>, CompressionError> {
+    let mut offset = 0;
+    let mut previous_doc = 0u32;
+    let mut postings = Vec::with_capacity(doc_count);
+
+    for _ in 0..doc_count {
+        let doc_gap = decode_u32(bytes, &mut offset)?;
+        let doc = previous_doc
+            .checked_add(doc_gap)
+            .ok_or(CompressionError::GapOverflow)?;
+        let term_freq = decode_u32(bytes, &mut offset)?;
+        let position_count = decode_u32(bytes, &mut offset)?;
+        let mut positions = Vec::with_capacity(position_count as usize);
+        let mut previous_position = 0u32;
+
+        for _ in 0..position_count {
+            let position_gap = decode_u32(bytes, &mut offset)?;
+            let position = previous_position
+                .checked_add(position_gap)
+                .ok_or(CompressionError::GapOverflow)?;
+            positions.push(position);
+            previous_position = position;
+        }
+
+        postings.push(DecodedPosting {
+            doc_id: DocId::from_u32(doc),
+            term_freq,
+            positions,
+        });
+        previous_doc = doc;
+    }
+
+    Ok(postings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompressedPostingList, CompressionError, DecodedPosting, decode_u32, encode_u32};
+    use crate::index::DocId;
+
+    #[test]
+    fn vbyte_round_trips_multi_byte_values() {
+        let mut bytes = Vec::new();
+        for value in [0, 1, 127, 128, 16_384, u32::MAX] {
+            encode_u32(value, &mut bytes);
+        }
+
+        let mut offset = 0;
+        for value in [0, 1, 127, 128, 16_384, u32::MAX] {
+            assert_eq!(decode_u32(&bytes, &mut offset).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn compressed_postings_round_trip_doc_gaps_and_position_gaps() {
+        let postings = vec![
+            DecodedPosting {
+                doc_id: DocId::from_u32(3),
+                term_freq: 2,
+                positions: vec![1, 4],
+            },
+            DecodedPosting {
+                doc_id: DocId::from_u32(10),
+                term_freq: 1,
+                positions: vec![8],
+            },
+        ];
+
+        let compressed = CompressedPostingList::from_postings(&postings).unwrap();
+
+        assert_eq!(compressed.decode().unwrap(), postings);
+    }
+
+    #[test]
+    fn malformed_vbyte_fails_without_panic() {
+        let mut offset = 0;
+
+        assert_eq!(
+            decode_u32(&[0x80], &mut offset).unwrap_err(),
+            CompressionError::UnexpectedEof
+        );
+    }
+}

--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -5,7 +5,9 @@ use std::{
 
 use crate::{index::DocumentField, tokenizer::FileType};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct DocId(u32);
 
 impl DocId {
@@ -18,7 +20,7 @@ impl DocId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DocumentMetadata {
     pub id: DocId,
     pub path: PathBuf,
@@ -63,7 +65,7 @@ impl DocumentMetadata {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct DocumentRegistry {
     documents: HashMap<DocId, DocumentMetadata>,
     path_to_id: HashMap<PathBuf, DocId>,
@@ -103,6 +105,10 @@ pub trait DocumentCatalog {
 impl DocumentRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn documents_iter(&self) -> impl Iterator<Item = (&DocId, &DocumentMetadata)> {
+        self.documents.iter()
     }
 }
 

--- a/crates/core/src/index/engine.rs
+++ b/crates/core/src/index/engine.rs
@@ -1,0 +1,178 @@
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, RwLock},
+};
+
+use crate::{
+    config::Config,
+    index::{InvertedIndex, Term, event_log::IndexEvent},
+    query::AnalyzedQuery,
+    ranking::{RankingAlgo, Scored},
+};
+
+#[derive(Debug, Clone)]
+pub struct SearchEngine {
+    index: Arc<RwLock<InvertedIndex>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SearchEngineError {
+    #[error("index lock poisoned while acquiring shared read access")]
+    ReadLockPoisoned,
+    #[error("index lock poisoned while acquiring exclusive write access")]
+    WriteLockPoisoned,
+}
+
+impl SearchEngine {
+    pub fn new(index: InvertedIndex) -> Self {
+        Self {
+            index: Arc::new(RwLock::new(index)),
+        }
+    }
+
+    pub fn num_docs(&self) -> Result<usize, SearchEngineError> {
+        let index = self
+            .index
+            .read()
+            .map_err(|_| SearchEngineError::ReadLockPoisoned)?;
+        Ok(index.num_docs())
+    }
+
+    pub fn search(
+        &self,
+        algo: &RankingAlgo,
+        query: &AnalyzedQuery,
+        top_n: usize,
+    ) -> Result<Option<Scored>, SearchEngineError> {
+        let index = self
+            .index
+            .read()
+            .map_err(|_| SearchEngineError::ReadLockPoisoned)?;
+        Ok(algo.rank(&*index, query, top_n))
+    }
+
+    pub fn update<F>(
+        &self,
+        path: &Path,
+        transform_fn: &F,
+        config: &Config,
+        fielded: bool,
+    ) -> Result<(), SearchEngineError>
+    where
+        F: Fn(&str) -> HashMap<Term, u32> + Sync,
+    {
+        let mut index = self
+            .index
+            .write()
+            .map_err(|_| SearchEngineError::WriteLockPoisoned)?;
+        if fielded {
+            index.update_fielded(path, config);
+        } else {
+            index.update(path, transform_fn);
+        }
+        Ok(())
+    }
+
+    pub fn apply_event<F>(
+        &self,
+        event: &IndexEvent,
+        transform_fn: &F,
+        config: &Config,
+        fielded: bool,
+    ) -> Result<(), SearchEngineError>
+    where
+        F: Fn(&str) -> HashMap<Term, u32> + Sync,
+    {
+        let mut index = self
+            .index
+            .write()
+            .map_err(|_| SearchEngineError::WriteLockPoisoned)?;
+        crate::index::event_log::apply_event(&mut index, event, transform_fn, config, fielded);
+        Ok(())
+    }
+
+    pub fn with_read<T>(
+        &self,
+        f: impl FnOnce(&InvertedIndex) -> T,
+    ) -> Result<T, SearchEngineError> {
+        let index = self
+            .index
+            .read()
+            .map_err(|_| SearchEngineError::ReadLockPoisoned)?;
+        Ok(f(&index))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc, thread};
+
+    use crate::{
+        config::Config,
+        index::{InvertedIndex, SearchEngine, Term},
+        query::AnalyzedQuery,
+        ranking::{BM25HyperParams, RankingAlgo},
+    };
+
+    fn transform(content: &str) -> HashMap<Term, u32> {
+        content
+            .split_whitespace()
+            .fold(HashMap::new(), |mut acc, word| {
+                *acc.entry(Term(word.to_string())).or_insert(0) += 1;
+                acc
+            })
+    }
+
+    fn config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: rust_stemmers::Stemmer::create(rust_stemmers::Algorithm::English),
+            stop_words: Default::default(),
+        }
+    }
+
+    #[test]
+    fn searches_can_hold_shared_access_concurrently() {
+        let engine = Arc::new(SearchEngine::new(InvertedIndex::from_documents(&[
+            ("a.rs", &[("rust", 2)]),
+            ("b.rs", &[("rust", 1)]),
+        ])));
+        let algo = RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 });
+        let query = AnalyzedQuery::new("rust", &config());
+
+        let handles = (0..4)
+            .map(|_| {
+                let engine = Arc::clone(&engine);
+                let algo = algo.clone();
+                let query = query.clone();
+                thread::spawn(move || engine.search(&algo, &query, 10).unwrap())
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            assert!(handle.join().unwrap().is_some());
+        }
+    }
+
+    #[test]
+    fn updates_take_exclusive_access_and_preserve_search_behavior() {
+        let source = tempfile::tempdir().unwrap();
+        let path = source.path().join("a.rs");
+        std::fs::write(&path, "old").unwrap();
+        let engine = SearchEngine::new(InvertedIndex::new(
+            source.path(),
+            transform,
+            None::<&std::path::Path>,
+        ));
+        std::fs::write(&path, "new").unwrap();
+
+        engine.update(&path, &transform, &config(), false).unwrap();
+
+        assert!(
+            engine
+                .with_read(|index| index.get_postings(&Term("old".to_string())).is_none())
+                .unwrap()
+        );
+    }
+}

--- a/crates/core/src/index/event_log.rs
+++ b/crates/core/src/index/event_log.rs
@@ -1,0 +1,194 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, BufRead, Write},
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    config::Config,
+    index::{InvertedIndex, Term},
+};
+
+const EVENT_LOG_FILE: &str = "events.jsonl";
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IndexEvent {
+    FileAdded { path: PathBuf },
+    FileModified { path: PathBuf },
+    FileDeleted { path: PathBuf },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EventLogError {
+    #[error("event log io failed for {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("event log json failed for {path} line {line}: {source}")]
+    Json {
+        path: PathBuf,
+        line: usize,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+pub fn event_log_path(index_dir: &Path) -> PathBuf {
+    index_dir.join(EVENT_LOG_FILE)
+}
+
+pub fn append_event(index_dir: &Path, event: &IndexEvent) -> Result<(), EventLogError> {
+    fs::create_dir_all(index_dir).map_err(|source| EventLogError::Io {
+        path: index_dir.to_path_buf(),
+        source,
+    })?;
+    let path = event_log_path(index_dir);
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&path)
+        .map_err(|source| EventLogError::Io {
+            path: path.clone(),
+            source,
+        })?;
+    serde_json::to_writer(&mut file, event).map_err(|source| EventLogError::Json {
+        path: path.clone(),
+        line: 0,
+        source,
+    })?;
+    file.write_all(b"\n")
+        .map_err(|source| EventLogError::Io { path, source })
+}
+
+pub fn read_events(index_dir: &Path) -> Result<Vec<IndexEvent>, EventLogError> {
+    let path = event_log_path(index_dir);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file = fs::File::open(&path).map_err(|source| EventLogError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let mut events = Vec::new();
+    for (line_idx, line) in io::BufReader::new(file).lines().enumerate() {
+        let line = line.map_err(|source| EventLogError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event = serde_json::from_str(&line).map_err(|source| EventLogError::Json {
+            path: path.clone(),
+            line: line_idx + 1,
+            source,
+        })?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+pub fn clear_events(index_dir: &Path) -> Result<(), EventLogError> {
+    let path = event_log_path(index_dir);
+    fs::write(&path, b"").map_err(|source| EventLogError::Io { path, source })
+}
+
+pub fn replay_events<F>(
+    index: &mut InvertedIndex,
+    events: &[IndexEvent],
+    transform_fn: &F,
+    config: &Config,
+    fielded: bool,
+) where
+    F: Fn(&str) -> std::collections::HashMap<Term, u32> + Sync,
+{
+    for event in events {
+        apply_event(index, event, transform_fn, config, fielded);
+    }
+}
+
+pub fn apply_event<F>(
+    index: &mut InvertedIndex,
+    event: &IndexEvent,
+    transform_fn: &F,
+    config: &Config,
+    fielded: bool,
+) where
+    F: Fn(&str) -> std::collections::HashMap<Term, u32> + Sync,
+{
+    match event {
+        IndexEvent::FileAdded { path } | IndexEvent::FileModified { path } => {
+            if fielded {
+                index.update_fielded(path, config);
+            } else {
+                index.update(path, transform_fn);
+            }
+        }
+        IndexEvent::FileDeleted { path } => index.remove_document(path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, fs};
+
+    use super::{IndexEvent, append_event, clear_events, read_events, replay_events};
+    use crate::{
+        config::Config,
+        index::{InvertedIndex, Term},
+    };
+
+    fn transform(content: &str) -> HashMap<Term, u32> {
+        content
+            .split_whitespace()
+            .fold(HashMap::new(), |mut acc, word| {
+                *acc.entry(Term(word.to_string())).or_insert(0) += 1;
+                acc
+            })
+    }
+
+    fn config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: rust_stemmers::Stemmer::create(rust_stemmers::Algorithm::English),
+            stop_words: Default::default(),
+        }
+    }
+
+    #[test]
+    fn event_log_replays_updates_in_order() {
+        let source = tempfile::tempdir().unwrap();
+        let index_dir = tempfile::tempdir().unwrap();
+        let path = source.path().join("a.rs");
+        fs::write(&path, "old").unwrap();
+        let mut index = InvertedIndex::new(source.path(), transform, None::<&std::path::Path>);
+        fs::write(&path, "new").unwrap();
+
+        append_event(index_dir.path(), &IndexEvent::FileModified { path }).unwrap();
+        let events = read_events(index_dir.path()).unwrap();
+        replay_events(&mut index, &events, &transform, &config(), false);
+
+        assert!(index.get_postings(&Term("old".to_string())).is_none());
+        assert!(index.get_postings(&Term("new".to_string())).is_some());
+    }
+
+    #[test]
+    fn clearing_events_compacts_replay_log() {
+        let index_dir = tempfile::tempdir().unwrap();
+        append_event(
+            index_dir.path(),
+            &IndexEvent::FileDeleted {
+                path: "a.rs".into(),
+            },
+        )
+        .unwrap();
+
+        clear_events(index_dir.path()).unwrap();
+
+        assert!(read_events(index_dir.path()).unwrap().is_empty());
+    }
+}

--- a/crates/core/src/index/inverted_file.rs
+++ b/crates/core/src/index/inverted_file.rs
@@ -1,0 +1,250 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use crate::index::{
+    DocId, InvertedIndex, Term, TermDocument,
+    compression::{CompressedPostingList, DecodedPosting, decode_postings},
+    skips::SkipTable,
+};
+
+const LEXICON_FILE: &str = "lexicon.json";
+const POSTINGS_FILE: &str = "postings.bin";
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LexiconEntry {
+    pub term: String,
+    pub offset: u64,
+    pub byte_len: u64,
+    pub document_frequency: usize,
+    pub collection_frequency: usize,
+}
+
+#[derive(Debug)]
+pub struct InvertedFileLayout {
+    lexicon: BTreeMap<String, LexiconEntry>,
+    postings: Vec<u8>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvertedFileError {
+    #[error("inverted file io failed for {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("lexicon json failed for {path}: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("compressed posting list for {term} is invalid: {source}")]
+    Compression {
+        term: String,
+        #[source]
+        source: crate::index::compression::CompressionError,
+    },
+}
+
+impl InvertedFileLayout {
+    pub fn write(
+        index: &InvertedIndex,
+        index_dir: &Path,
+    ) -> Result<Vec<LexiconEntry>, InvertedFileError> {
+        fs::create_dir_all(index_dir).map_err(|source| InvertedFileError::Io {
+            path: index_dir.to_path_buf(),
+            source,
+        })?;
+
+        let mut postings_bytes = Vec::new();
+        let mut lexicon = Vec::new();
+        let mut terms = index.postings_iter().collect::<Vec<_>>();
+        terms.sort_by_key(|(term, _)| *term);
+
+        for (term, documents) in terms {
+            let decoded = documents
+                .iter()
+                .map(|(doc_id, term_document)| DecodedPosting {
+                    doc_id: *doc_id,
+                    term_freq: term_document.term_freq as u32,
+                    positions: Vec::new(),
+                })
+                .collect::<Vec<_>>();
+            let compressed = CompressedPostingList::from_postings(&decoded).map_err(|source| {
+                InvertedFileError::Compression {
+                    term: term.0.clone(),
+                    source,
+                }
+            })?;
+            let offset = postings_bytes.len() as u64;
+            postings_bytes.extend_from_slice(compressed.bytes());
+            lexicon.push(LexiconEntry {
+                term: term.0.clone(),
+                offset,
+                byte_len: compressed.bytes().len() as u64,
+                document_frequency: documents.len(),
+                collection_frequency: documents.values().map(|document| document.term_freq).sum(),
+            });
+        }
+
+        let postings_path = index_dir.join(POSTINGS_FILE);
+        fs::write(&postings_path, &postings_bytes).map_err(|source| InvertedFileError::Io {
+            path: postings_path,
+            source,
+        })?;
+
+        let lexicon_path = index_dir.join(LEXICON_FILE);
+        let json =
+            serde_json::to_vec_pretty(&lexicon).map_err(|source| InvertedFileError::Json {
+                path: lexicon_path.clone(),
+                source,
+            })?;
+        fs::write(&lexicon_path, json).map_err(|source| InvertedFileError::Io {
+            path: lexicon_path,
+            source,
+        })?;
+
+        Ok(lexicon)
+    }
+
+    pub fn open(index_dir: &Path) -> Result<Self, InvertedFileError> {
+        let lexicon_path = index_dir.join(LEXICON_FILE);
+        let postings_path = index_dir.join(POSTINGS_FILE);
+        let lexicon_entries: Vec<LexiconEntry> =
+            serde_json::from_slice(&fs::read(&lexicon_path).map_err(|source| {
+                InvertedFileError::Io {
+                    path: lexicon_path.clone(),
+                    source,
+                }
+            })?)
+            .map_err(|source| InvertedFileError::Json {
+                path: lexicon_path,
+                source,
+            })?;
+        let postings = fs::read(&postings_path).map_err(|source| InvertedFileError::Io {
+            path: postings_path,
+            source,
+        })?;
+        let lexicon = lexicon_entries
+            .into_iter()
+            .map(|entry| (entry.term.clone(), entry))
+            .collect();
+
+        Ok(Self { lexicon, postings })
+    }
+
+    pub fn lexicon_len(&self) -> usize {
+        self.lexicon.len()
+    }
+
+    pub fn lexicon_entry(&self, term: &str) -> Option<&LexiconEntry> {
+        self.lexicon.get(term)
+    }
+
+    pub fn postings_for(
+        &self,
+        term: &str,
+    ) -> Result<Option<BTreeMap<DocId, TermDocument>>, InvertedFileError> {
+        let Some(entry) = self.lexicon.get(term) else {
+            return Ok(None);
+        };
+        let start = entry.offset as usize;
+        let end = start + entry.byte_len as usize;
+        let postings = decode_postings(&self.postings[start..end], entry.document_frequency)
+            .map_err(|source| InvertedFileError::Compression {
+                term: term.to_string(),
+                source,
+            })?;
+        Ok(Some(
+            postings
+                .into_iter()
+                .map(|posting| {
+                    (
+                        posting.doc_id,
+                        TermDocument::unfielded(0, posting.term_freq as usize),
+                    )
+                })
+                .collect(),
+        ))
+    }
+
+    pub fn skip_table_for(
+        &self,
+        term: &str,
+        block_size: usize,
+    ) -> Result<Option<SkipTable>, InvertedFileError> {
+        let Some(entry) = self.lexicon.get(term) else {
+            return Ok(None);
+        };
+        let start = entry.offset as usize;
+        let end = start + entry.byte_len as usize;
+        SkipTable::build(
+            &self.postings[start..end],
+            entry.document_frequency,
+            block_size,
+        )
+        .map(Some)
+        .map_err(|source| InvertedFileError::Compression {
+            term: term.to_string(),
+            source,
+        })
+    }
+}
+
+pub fn materialize_compressed_postings(
+    index: &InvertedIndex,
+) -> Result<HashMap<Term, CompressedPostingList>, InvertedFileError> {
+    index
+        .postings_iter()
+        .map(|(term, documents)| {
+            let decoded = documents
+                .iter()
+                .map(|(doc_id, term_document)| DecodedPosting {
+                    doc_id: *doc_id,
+                    term_freq: term_document.term_freq as u32,
+                    positions: Vec::new(),
+                })
+                .collect::<Vec<_>>();
+            CompressedPostingList::from_postings(&decoded)
+                .map(|compressed| (term.clone(), compressed))
+                .map_err(|source| InvertedFileError::Compression {
+                    term: term.0.clone(),
+                    source,
+                })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InvertedFileLayout, materialize_compressed_postings};
+    use crate::index::{InvertedIndex, Term};
+
+    #[test]
+    fn compressed_postings_are_smaller_than_plain_doc_frequency_pairs() {
+        let index =
+            InvertedIndex::from_documents(&[("a.rs", &[("rust", 2)]), ("b.rs", &[("rust", 1)])]);
+        let compressed = materialize_compressed_postings(&index).unwrap();
+        let rust = compressed.get(&Term("rust".to_string())).unwrap();
+
+        assert!(rust.bytes().len() < 2 * std::mem::size_of::<(u32, u32)>());
+    }
+
+    #[test]
+    fn inverted_file_loads_lexicon_before_posting_lookup() {
+        let index_dir = tempfile::tempdir().unwrap();
+        let index =
+            InvertedIndex::from_documents(&[("a.rs", &[("rust", 2)]), ("b.rs", &[("search", 1)])]);
+        InvertedFileLayout::write(&index, index_dir.path()).unwrap();
+
+        let layout = InvertedFileLayout::open(index_dir.path()).unwrap();
+
+        assert_eq!(layout.lexicon_len(), 2);
+        assert!(layout.lexicon_entry("rust").is_some());
+        assert!(layout.postings_for("rust").unwrap().is_some());
+    }
+}

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
 };
 
@@ -15,7 +15,7 @@ use crate::{
     tokenizer::{AnalyzerProfile, FileType},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TermDocument {
     pub length: usize,
     pub term_freq: usize,
@@ -42,7 +42,7 @@ impl TermDocument {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CorpusStats {
     pub document_count: usize,
     pub total_token_count: u64,
@@ -51,7 +51,7 @@ pub struct CorpusStats {
     pub high_frequency_terms: Vec<TermFrequencySummary>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TermFrequencySummary {
     pub term: String,
     pub collection_frequency: usize,
@@ -76,9 +76,9 @@ impl IndexBuildReport {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InvertedIndex<R = DocumentRegistry> {
-    postings: HashMap<Term, HashMap<DocId, TermDocument>>,
+    postings: HashMap<Term, BTreeMap<DocId, TermDocument>>,
     documents: R,
     document_norms: HashMap<DocId, f64>,
 }
@@ -98,6 +98,23 @@ struct ProcessedDocument {
 type TestDocumentSpec<'a> = (&'a str, &'a [(&'a str, u32)], u64);
 
 impl InvertedIndex<DocumentRegistry> {
+    pub fn from_parts(
+        postings: HashMap<Term, BTreeMap<DocId, TermDocument>>,
+        documents: DocumentRegistry,
+    ) -> Self {
+        let document_norms = Self::compute_document_norms(&postings, documents.len());
+
+        Self {
+            postings,
+            documents,
+            document_norms,
+        }
+    }
+
+    pub fn documents_iter(&self) -> impl Iterator<Item = (&DocId, &DocumentMetadata)> {
+        self.documents.documents_iter()
+    }
+
     #[cfg(test)]
     pub(crate) fn from_documents(docs: &[(&str, &[(&str, u32)])]) -> Self {
         Self::from_documents_with_sizes(
@@ -111,7 +128,7 @@ impl InvertedIndex<DocumentRegistry> {
     #[cfg(test)]
     pub(crate) fn from_documents_with_sizes(docs: &[TestDocumentSpec<'_>]) -> Self {
         let mut documents = DocumentRegistry::new();
-        let mut postings: HashMap<Term, HashMap<DocId, TermDocument>> = HashMap::new();
+        let mut postings: HashMap<Term, BTreeMap<DocId, TermDocument>> = HashMap::new();
 
         for &(path, terms, file_size_bytes) in docs {
             let total_len: usize = terms.iter().map(|(_, c)| *c as usize).sum();
@@ -232,7 +249,7 @@ where
         entry_path: &Path,
         content: &str,
         transform_fn: &F,
-    ) -> HashMap<Term, HashMap<DocId, TermDocument>>
+    ) -> HashMap<Term, BTreeMap<DocId, TermDocument>>
     where
         F: Fn(&str) -> HashMap<Term, u32> + Sync,
     {
@@ -322,8 +339,8 @@ where
     fn postings_for_document(
         doc_id: DocId,
         document: &ProcessedDocument,
-    ) -> HashMap<Term, HashMap<DocId, TermDocument>> {
-        let mut local_map: HashMap<Term, HashMap<DocId, TermDocument>> = HashMap::new();
+    ) -> HashMap<Term, BTreeMap<DocId, TermDocument>> {
+        let mut local_map: HashMap<Term, BTreeMap<DocId, TermDocument>> = HashMap::new();
 
         for (term, freq) in &document.term_frequencies {
             let field_frequencies = document
@@ -351,7 +368,7 @@ where
 
     fn insert_processed_document(
         registry: &mut impl DocumentCatalog,
-        postings: &mut HashMap<Term, HashMap<DocId, TermDocument>>,
+        postings: &mut HashMap<Term, BTreeMap<DocId, TermDocument>>,
         document: ProcessedDocument,
     ) {
         let doc_id = registry.insert_or_update_with_fields(
@@ -367,11 +384,11 @@ where
         }
     }
 
-    pub fn get_postings(&self, term: &Term) -> Option<&HashMap<DocId, TermDocument>> {
+    pub fn get_postings(&self, term: &Term) -> Option<&BTreeMap<DocId, TermDocument>> {
         self.postings.get(term)
     }
 
-    pub fn postings_iter(&self) -> impl Iterator<Item = (&Term, &HashMap<DocId, TermDocument>)> {
+    pub fn postings_iter(&self) -> impl Iterator<Item = (&Term, &BTreeMap<DocId, TermDocument>)> {
         self.postings.iter()
     }
 
@@ -511,7 +528,7 @@ where
     }
 
     fn compute_document_norms(
-        postings: &HashMap<Term, HashMap<DocId, TermDocument>>,
+        postings: &HashMap<Term, BTreeMap<DocId, TermDocument>>,
         num_docs: usize,
     ) -> HashMap<DocId, f64> {
         let mut squared_weights = HashMap::new();
@@ -706,7 +723,7 @@ fn extract_string_literals(content: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::{HashMap, HashSet},
+        collections::{BTreeMap, HashMap, HashSet},
         path::{Path, PathBuf},
     };
 
@@ -733,7 +750,7 @@ mod tests {
     }
 
     fn get_term_doc<'a>(
-        result: &'a HashMap<Term, HashMap<DocId, super::TermDocument>>,
+        result: &'a HashMap<Term, BTreeMap<DocId, super::TermDocument>>,
         term: &str,
         doc_id: DocId,
     ) -> &'a super::TermDocument {

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -1,7 +1,14 @@
+pub mod compression;
 pub mod corpus;
 pub mod document_registry;
+pub mod engine;
+pub mod event_log;
 pub mod field;
+pub mod inverted_file;
 pub mod inverted_index;
+pub mod reader;
+pub mod skips;
+pub mod snapshot;
 pub mod term;
 
 pub use corpus::{
@@ -9,9 +16,12 @@ pub use corpus::{
     SkippedDocument,
 };
 pub use document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry};
+pub use engine::{SearchEngine, SearchEngineError};
+pub use event_log::IndexEvent;
 pub use field::DocumentField;
 pub use inverted_index::{
     CorpusStats, IndexBuildReport, IndexBuildResult, InvertedIndex, TermDocument,
     TermFrequencySummary,
 };
+pub use reader::{OwnedPostingList, PostingList, RankedIndexReader};
 pub use term::Term;

--- a/crates/core/src/index/reader.rs
+++ b/crates/core/src/index/reader.rs
@@ -1,0 +1,193 @@
+use std::{collections::BTreeMap, path::Path};
+
+use crate::index::{DocId, DocumentField, DocumentMetadata, InvertedIndex, Term, TermDocument};
+
+pub trait PostingList {
+    type Iter<'a>: Iterator<Item = (DocId, &'a TermDocument)> + Send
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    fn get(&self, doc_id: DocId) -> Option<&TermDocument>;
+    fn iter(&self) -> Self::Iter<'_>;
+}
+
+pub struct BTreePostingIter<'a>(std::collections::btree_map::Iter<'a, DocId, TermDocument>);
+
+impl<'a> Iterator for BTreePostingIter<'a> {
+    type Item = (DocId, &'a TermDocument);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(doc_id, term_doc)| (*doc_id, term_doc))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedPostingList {
+    postings: Vec<(DocId, TermDocument)>,
+}
+
+impl OwnedPostingList {
+    pub fn new(mut postings: Vec<(DocId, TermDocument)>) -> Self {
+        postings.sort_by_key(|(doc_id, _)| *doc_id);
+        Self { postings }
+    }
+}
+
+pub struct OwnedPostingIter<'a>(std::slice::Iter<'a, (DocId, TermDocument)>);
+
+impl<'a> Iterator for OwnedPostingIter<'a> {
+    type Item = (DocId, &'a TermDocument);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(doc_id, term_doc)| (*doc_id, term_doc))
+    }
+}
+
+impl PostingList for OwnedPostingList {
+    type Iter<'a>
+        = OwnedPostingIter<'a>
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize {
+        self.postings.len()
+    }
+
+    fn get(&self, doc_id: DocId) -> Option<&TermDocument> {
+        self.postings
+            .binary_search_by_key(&doc_id, |(candidate, _)| *candidate)
+            .ok()
+            .map(|idx| &self.postings[idx].1)
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        OwnedPostingIter(self.postings.iter())
+    }
+}
+
+impl PostingList for BTreeMap<DocId, TermDocument> {
+    type Iter<'a>
+        = BTreePostingIter<'a>
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize {
+        BTreeMap::len(self)
+    }
+
+    fn get(&self, doc_id: DocId) -> Option<&TermDocument> {
+        BTreeMap::get(self, &doc_id)
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        BTreePostingIter(BTreeMap::iter(self))
+    }
+}
+
+impl PostingList for &BTreeMap<DocId, TermDocument> {
+    type Iter<'a>
+        = BTreePostingIter<'a>
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize {
+        BTreeMap::len(self)
+    }
+
+    fn get(&self, doc_id: DocId) -> Option<&TermDocument> {
+        BTreeMap::get(self, &doc_id)
+    }
+
+    fn iter(&self) -> Self::Iter<'_> {
+        BTreePostingIter(BTreeMap::iter(self))
+    }
+}
+
+pub trait RankedIndexReader {
+    type Postings<'a>: PostingList + Sync
+    where
+        Self: 'a;
+
+    fn postings(&self, term: &Term) -> Option<Self::Postings<'_>>;
+    fn document(&self, id: DocId) -> Option<&DocumentMetadata>;
+    fn doc_id(&self, path: &Path) -> Option<DocId>;
+    fn document_norm(&self, doc_id: DocId) -> Option<f64>;
+    fn num_docs(&self) -> usize;
+    fn avg_doc_length(&self) -> f64;
+    fn avg_field_length(&self, field: DocumentField) -> f64;
+    fn doc_freq(&self, term: &Term) -> usize;
+}
+
+impl RankedIndexReader for InvertedIndex {
+    type Postings<'a> = &'a BTreeMap<DocId, TermDocument>;
+
+    fn postings(&self, term: &Term) -> Option<Self::Postings<'_>> {
+        InvertedIndex::get_postings(self, term)
+    }
+
+    fn document(&self, id: DocId) -> Option<&DocumentMetadata> {
+        InvertedIndex::document(self, id)
+    }
+
+    fn doc_id(&self, path: &Path) -> Option<DocId> {
+        InvertedIndex::doc_id(self, path)
+    }
+
+    fn document_norm(&self, doc_id: DocId) -> Option<f64> {
+        InvertedIndex::document_norm(self, doc_id)
+    }
+
+    fn num_docs(&self) -> usize {
+        InvertedIndex::num_docs(self)
+    }
+
+    fn avg_doc_length(&self) -> f64 {
+        InvertedIndex::avg_doc_length(self)
+    }
+
+    fn avg_field_length(&self, field: DocumentField) -> f64 {
+        InvertedIndex::avg_field_length(self, field)
+    }
+
+    fn doc_freq(&self, term: &Term) -> usize {
+        InvertedIndex::doc_freq(self, term)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::index::{
+        DocId, InvertedIndex, OwnedPostingList, PostingList, RankedIndexReader, Term, TermDocument,
+    };
+
+    #[test]
+    fn in_memory_index_implements_ranked_reader_postings() {
+        let index =
+            InvertedIndex::from_documents(&[("a.rs", &[("rust", 2)]), ("b.rs", &[("rust", 1)])]);
+        let postings = index.postings(&Term("rust".to_string())).unwrap();
+        let doc_ids = PostingList::iter(&postings)
+            .map(|(doc_id, _)| doc_id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(doc_ids, vec![DocId::from_u32(0), DocId::from_u32(1)]);
+    }
+
+    #[test]
+    fn owned_posting_list_supports_sorted_lookup_and_iteration() {
+        let postings = OwnedPostingList::new(vec![
+            (DocId::from_u32(9), TermDocument::unfielded(3, 1)),
+            (DocId::from_u32(2), TermDocument::unfielded(5, 2)),
+        ]);
+        let doc_ids = postings
+            .iter()
+            .map(|(doc_id, _)| doc_id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(doc_ids, vec![DocId::from_u32(2), DocId::from_u32(9)]);
+        assert_eq!(postings.get(DocId::from_u32(2)).unwrap().term_freq, 2);
+    }
+}

--- a/crates/core/src/index/skips.rs
+++ b/crates/core/src/index/skips.rs
@@ -1,0 +1,184 @@
+use crate::index::{
+    DocId,
+    compression::{CompressionError, decode_u32},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkipPointer {
+    pub target_doc_id: DocId,
+    pub byte_offset: usize,
+    pub ordinal: usize,
+    pub previous_doc_id: DocId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkipTable {
+    pointers: Vec<SkipPointer>,
+    block_size: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IntersectionStats {
+    pub inspected_without_skips: usize,
+    pub inspected_with_skips: usize,
+}
+
+impl SkipTable {
+    pub fn build(
+        encoded: &[u8],
+        doc_count: usize,
+        block_size: usize,
+    ) -> Result<Self, CompressionError> {
+        let mut pointers = Vec::new();
+        let mut offset = 0;
+        let mut previous_doc = 0;
+
+        for ordinal in 0..doc_count {
+            if ordinal > 0 && ordinal % block_size == 0 {
+                pointers.push(SkipPointer {
+                    target_doc_id: DocId::from_u32(previous_doc),
+                    byte_offset: offset,
+                    ordinal,
+                    previous_doc_id: DocId::from_u32(previous_doc),
+                });
+            }
+
+            let doc_gap = decode_u32(encoded, &mut offset)?;
+            previous_doc += doc_gap;
+            let _term_frequency = decode_u32(encoded, &mut offset)?;
+            let position_count = decode_u32(encoded, &mut offset)?;
+            for _ in 0..position_count {
+                let _position_gap = decode_u32(encoded, &mut offset)?;
+            }
+        }
+
+        Ok(Self {
+            pointers,
+            block_size,
+        })
+    }
+
+    pub fn pointers(&self) -> &[SkipPointer] {
+        &self.pointers
+    }
+
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+}
+
+pub fn intersect_doc_ids_with_optional_skips(
+    left: &[DocId],
+    right: &[DocId],
+    use_skips: bool,
+) -> (Vec<DocId>, IntersectionStats) {
+    if !use_skips {
+        let (matches, inspected) = intersect_linear(left, right);
+        return (
+            matches,
+            IntersectionStats {
+                inspected_without_skips: inspected,
+                inspected_with_skips: inspected,
+            },
+        );
+    }
+
+    let block = (left.len().max(right.len()) as f64).sqrt().max(2.0) as usize;
+    let mut matches = Vec::new();
+    let mut inspected = 0;
+    let mut left_idx = 0;
+    let mut right_idx = 0;
+
+    while left_idx < left.len() && right_idx < right.len() {
+        inspected += 1;
+        let left_doc = left[left_idx];
+        let right_doc = right[right_idx];
+
+        if left_doc == right_doc {
+            matches.push(left_doc);
+            left_idx += 1;
+            right_idx += 1;
+        } else if left_doc < right_doc {
+            left_idx = skip_forward(left, left_idx, right_doc, block);
+        } else {
+            right_idx = skip_forward(right, right_idx, left_doc, block);
+        }
+    }
+
+    let (_, baseline) = intersect_linear(left, right);
+    (
+        matches,
+        IntersectionStats {
+            inspected_without_skips: baseline,
+            inspected_with_skips: inspected,
+        },
+    )
+}
+
+fn skip_forward(list: &[DocId], current: usize, target: DocId, block: usize) -> usize {
+    let mut next = current + 1;
+    while next + block < list.len() && list[next + block] <= target {
+        next += block;
+    }
+    next
+}
+
+fn intersect_linear(left: &[DocId], right: &[DocId]) -> (Vec<DocId>, usize) {
+    let mut matches = Vec::new();
+    let mut inspected = 0;
+    let mut left_idx = 0;
+    let mut right_idx = 0;
+
+    while left_idx < left.len() && right_idx < right.len() {
+        inspected += 1;
+        match left[left_idx].cmp(&right[right_idx]) {
+            std::cmp::Ordering::Equal => {
+                matches.push(left[left_idx]);
+                left_idx += 1;
+                right_idx += 1;
+            }
+            std::cmp::Ordering::Less => left_idx += 1,
+            std::cmp::Ordering::Greater => right_idx += 1,
+        }
+    }
+
+    (matches, inspected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SkipTable, intersect_doc_ids_with_optional_skips};
+    use crate::index::{
+        DocId,
+        compression::{CompressedPostingList, DecodedPosting},
+    };
+
+    #[test]
+    fn skip_table_records_block_offsets_for_compressed_postings() {
+        let postings = (0..8)
+            .map(|doc_id| DecodedPosting {
+                doc_id: DocId::from_u32(doc_id * 2),
+                term_freq: 1,
+                positions: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        let compressed = CompressedPostingList::from_postings(&postings).unwrap();
+
+        let skips = SkipTable::build(compressed.bytes(), compressed.doc_count(), 3).unwrap();
+
+        assert_eq!(skips.pointers().len(), 2);
+        assert_eq!(skips.pointers()[0].ordinal, 3);
+    }
+
+    #[test]
+    fn skipped_intersection_matches_linear_intersection() {
+        let left = (0..100).map(DocId::from_u32).collect::<Vec<_>>();
+        let right = (50..150).map(DocId::from_u32).collect::<Vec<_>>();
+
+        let (linear, _) = intersect_doc_ids_with_optional_skips(&left, &right, false);
+        let (skipped, stats) = intersect_doc_ids_with_optional_skips(&left, &right, true);
+
+        assert_eq!(skipped, linear);
+        assert!(stats.inspected_with_skips < stats.inspected_without_skips);
+    }
+}

--- a/crates/core/src/index/snapshot.rs
+++ b/crates/core/src/index/snapshot.rs
@@ -1,0 +1,292 @@
+use std::{
+    collections::{BTreeMap, HashMap, hash_map::DefaultHasher},
+    fs,
+    hash::{Hash, Hasher},
+    io,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use crate::{
+    config::Config,
+    index::{
+        CorpusStats, DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry, InvertedIndex,
+        Term, TermDocument,
+    },
+};
+
+pub const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+const SNAPSHOT_FILE: &str = "snapshot.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SnapshotMetadata {
+    pub schema_version: u32,
+    pub config_hash: u64,
+    pub source_root: PathBuf,
+    pub corpus_stats: CorpusStats,
+    pub created_unix_secs: u64,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct IndexSnapshot {
+    metadata: SnapshotMetadata,
+    documents: Vec<DocumentMetadata>,
+    postings: Vec<TermSnapshot>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct TermSnapshot {
+    term: String,
+    documents: Vec<TermDocumentSnapshot>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct TermDocumentSnapshot {
+    doc_id: u32,
+    term_document: TermDocument,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("snapshot io failed for {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("snapshot serialization failed for {path}: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("snapshot schema version {found} is incompatible with {expected}")]
+    Schema { found: u32, expected: u32 },
+    #[error("snapshot config hash {found} does not match current config hash {expected}")]
+    ConfigHash { found: u64, expected: u64 },
+    #[error("snapshot source root {found} does not match current source root {expected}")]
+    SourceRoot { found: PathBuf, expected: PathBuf },
+}
+
+pub fn snapshot_path(index_dir: &Path) -> PathBuf {
+    index_dir.join(SNAPSHOT_FILE)
+}
+
+pub fn config_hash(config: &Config) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    config.n_grams.hash(&mut hasher);
+    let mut stop_words = config.stop_words.iter().collect::<Vec<_>>();
+    stop_words.sort();
+    for word in stop_words {
+        word.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+pub fn write_snapshot(
+    index: &InvertedIndex,
+    index_dir: &Path,
+    source_root: &Path,
+    config: &Config,
+) -> Result<SnapshotMetadata, SnapshotError> {
+    fs::create_dir_all(index_dir).map_err(|source| SnapshotError::Io {
+        path: index_dir.to_path_buf(),
+        source,
+    })?;
+
+    let metadata = SnapshotMetadata {
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+        config_hash: config_hash(config),
+        source_root: source_root.to_path_buf(),
+        corpus_stats: index.corpus_stats(10),
+        created_unix_secs: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_secs()),
+    };
+    let snapshot = IndexSnapshot::from_index(index, metadata.clone());
+    let path = snapshot_path(index_dir);
+    let json = serde_json::to_vec_pretty(&snapshot).map_err(|source| SnapshotError::Json {
+        path: path.clone(),
+        source,
+    })?;
+    fs::write(&path, json).map_err(|source| SnapshotError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(metadata)
+}
+
+pub fn load_snapshot(
+    index_dir: &Path,
+    source_root: &Path,
+    config: &Config,
+) -> Result<InvertedIndex, SnapshotError> {
+    let path = snapshot_path(index_dir);
+    let json = fs::read(&path).map_err(|source| SnapshotError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let snapshot: IndexSnapshot =
+        serde_json::from_slice(&json).map_err(|source| SnapshotError::Json {
+            path: path.clone(),
+            source,
+        })?;
+    snapshot.validate(source_root, config)?;
+    Ok(snapshot.into_index())
+}
+
+impl IndexSnapshot {
+    fn from_index(index: &InvertedIndex, metadata: SnapshotMetadata) -> Self {
+        let mut documents = index
+            .documents_iter()
+            .map(|(_, metadata)| metadata.clone())
+            .collect::<Vec<_>>();
+        documents.sort_by_key(|metadata| metadata.id);
+
+        let mut postings = index
+            .postings_iter()
+            .map(|(term, documents)| TermSnapshot {
+                term: term.0.clone(),
+                documents: documents
+                    .iter()
+                    .map(|(doc_id, term_document)| TermDocumentSnapshot {
+                        doc_id: doc_id.as_u32(),
+                        term_document: term_document.clone(),
+                    })
+                    .collect(),
+            })
+            .collect::<Vec<_>>();
+        postings.sort_by_key(|snapshot| snapshot.term.clone());
+
+        Self {
+            metadata,
+            documents,
+            postings,
+        }
+    }
+
+    fn validate(&self, source_root: &Path, config: &Config) -> Result<(), SnapshotError> {
+        if self.metadata.schema_version != SNAPSHOT_SCHEMA_VERSION {
+            return Err(SnapshotError::Schema {
+                found: self.metadata.schema_version,
+                expected: SNAPSHOT_SCHEMA_VERSION,
+            });
+        }
+
+        let expected_config_hash = config_hash(config);
+        if self.metadata.config_hash != expected_config_hash {
+            return Err(SnapshotError::ConfigHash {
+                found: self.metadata.config_hash,
+                expected: expected_config_hash,
+            });
+        }
+
+        if self.metadata.source_root != source_root {
+            return Err(SnapshotError::SourceRoot {
+                found: self.metadata.source_root.clone(),
+                expected: source_root.to_path_buf(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn into_index(self) -> InvertedIndex {
+        let mut registry = DocumentRegistry::new();
+        for metadata in self.documents {
+            registry.insert_or_update_with_fields(
+                metadata.path,
+                metadata.token_length,
+                metadata.file_size_bytes,
+                metadata.file_type,
+                metadata.field_lengths,
+            );
+        }
+
+        let postings = self
+            .postings
+            .into_iter()
+            .map(|term| {
+                let documents = term
+                    .documents
+                    .into_iter()
+                    .map(|document| (DocId::from_u32(document.doc_id), document.term_document))
+                    .collect::<BTreeMap<_, _>>();
+                (Term(term.term), documents)
+            })
+            .collect::<HashMap<_, _>>();
+
+        InvertedIndex::from_parts(postings, registry)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, fs};
+
+    use rust_stemmers::{Algorithm, Stemmer};
+
+    use super::{SnapshotError, load_snapshot, snapshot_path, write_snapshot};
+    use crate::{
+        config::Config,
+        index::InvertedIndex,
+        query::AnalyzedQuery,
+        ranking::{BM25HyperParams, RankingAlgo},
+        tokenizer::n_gram_transform,
+    };
+
+    fn config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: Stemmer::create(Algorithm::English),
+            stop_words: HashSet::new(),
+        }
+    }
+
+    #[test]
+    fn snapshot_round_trips_ranked_search_results() {
+        let source = tempfile::tempdir().unwrap();
+        let index_dir = tempfile::tempdir().unwrap();
+        fs::write(source.path().join("a.rs"), "rust rust search").unwrap();
+        fs::write(source.path().join("b.rs"), "search").unwrap();
+        let config = config();
+        let index = InvertedIndex::new(
+            source.path(),
+            |content| n_gram_transform(content, &config),
+            Some(source.path()),
+        );
+        write_snapshot(&index, index_dir.path(), source.path(), &config).unwrap();
+
+        let loaded = load_snapshot(index_dir.path(), source.path(), &config).unwrap();
+        let query = AnalyzedQuery::new("rust search", &config);
+        let algo = RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 });
+
+        assert_eq!(
+            algo.rank(&loaded, &query, 10),
+            algo.rank(&index, &query, 10)
+        );
+    }
+
+    #[test]
+    fn snapshot_rejects_invalid_metadata() {
+        let source = tempfile::tempdir().unwrap();
+        let index_dir = tempfile::tempdir().unwrap();
+        fs::write(source.path().join("a.rs"), "rust").unwrap();
+        let config = config();
+        let index = InvertedIndex::new(
+            source.path(),
+            |content| n_gram_transform(content, &config),
+            Some(source.path()),
+        );
+        write_snapshot(&index, index_dir.path(), source.path(), &config).unwrap();
+
+        let mut json = fs::read_to_string(snapshot_path(index_dir.path())).unwrap();
+        json = json.replace("\"schema_version\": 1", "\"schema_version\": 99");
+        fs::write(snapshot_path(index_dir.path()), json).unwrap();
+
+        assert!(matches!(
+            load_snapshot(index_dir.path(), source.path(), &config).unwrap_err(),
+            SnapshotError::Schema { .. }
+        ));
+    }
+}

--- a/crates/core/src/index/term.rs
+++ b/crates/core/src/index/term.rs
@@ -1,2 +1,4 @@
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(
+    Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, serde::Serialize, serde::Deserialize,
+)]
 pub struct Term(pub String);

--- a/crates/core/src/ranking/bm25.rs
+++ b/crates/core/src/ranking/bm25.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-
 use dashmap::DashMap;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
     error::RankingError,
-    index::{DocId, InvertedIndex, Term, TermDocument},
+    index::{DocId, PostingList, RankedIndexReader, Term},
     query::{AnalyzedQuery, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
@@ -32,27 +30,33 @@ pub struct BM25 {
 }
 
 impl Scorer for BM25 {
-    fn score(
+    fn score<I, P>(
         &self,
-        inverted_index: &InvertedIndex,
+        index: &I,
         _: &AnalyzedQuery,
         _: &Term,
         query_term: QueryTerm,
-        documents: &HashMap<DocId, TermDocument>,
+        documents: &P,
         scores: &DashMap<DocId, f64>,
-    ) {
-        let avgdl = inverted_index.avg_doc_length();
-        let num_docs = inverted_index.num_docs();
+    ) where
+        I: RankedIndexReader + Sync,
+        P: PostingList + Sync,
+    {
+        let avgdl = index.avg_doc_length();
+        let num_docs = index.num_docs();
 
         let idf = idf(num_docs, documents.len());
 
-        documents.par_iter().for_each(|(doc_id, term_doc)| {
-            let tf = term_doc.term_freq as f64;
-            let doc_length = term_doc.length as f64;
-            let score = self.score_term(query_term.weight, idf, tf, doc_length, avgdl);
+        documents
+            .iter()
+            .par_bridge()
+            .for_each(|(doc_id, term_doc)| {
+                let tf = term_doc.term_freq as f64;
+                let doc_length = term_doc.length as f64;
+                let score = self.score_term(query_term.weight, idf, tf, doc_length, avgdl);
 
-            *scores.entry(*doc_id).or_insert(0.0) += score;
-        });
+                *scores.entry(doc_id).or_insert(0.0) += score;
+            });
     }
 }
 

--- a/crates/core/src/ranking/bm25f.rs
+++ b/crates/core/src/ranking/bm25f.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use dashmap::DashMap;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
     error::RankingError,
-    index::{DocId, DocumentField, InvertedIndex, Term, TermDocument},
+    index::{DocId, DocumentField, PostingList, RankedIndexReader, Term, TermDocument},
     query::{AnalyzedQuery, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
@@ -48,11 +48,10 @@ pub struct BM25F {
 }
 
 impl BM25F {
-    pub fn weighted_term_frequency(
-        &self,
-        inverted_index: &InvertedIndex,
-        term_doc: &TermDocument,
-    ) -> f64 {
+    pub fn weighted_term_frequency<I>(&self, index: &I, term_doc: &TermDocument) -> f64
+    where
+        I: RankedIndexReader,
+    {
         if term_doc.field_frequencies.is_empty() {
             return term_doc.term_freq as f64;
         }
@@ -66,7 +65,7 @@ impl BM25F {
                 }
 
                 let field_length = term_doc.field_length(field) as f64;
-                let avg_field_length = inverted_index.avg_field_length(field);
+                let avg_field_length = index.avg_field_length(field);
                 if avg_field_length == 0.0 {
                     return 0.0;
                 }
@@ -90,24 +89,30 @@ impl BM25F {
 }
 
 impl Scorer for BM25F {
-    fn score(
+    fn score<I, P>(
         &self,
-        inverted_index: &InvertedIndex,
+        index: &I,
         _: &AnalyzedQuery,
         _: &Term,
         query_term: QueryTerm,
-        documents: &HashMap<DocId, TermDocument>,
+        documents: &P,
         scores: &DashMap<DocId, f64>,
-    ) {
-        let num_docs = inverted_index.num_docs();
+    ) where
+        I: RankedIndexReader + Sync,
+        P: PostingList + Sync,
+    {
+        let num_docs = index.num_docs();
         let idf = idf(num_docs, documents.len());
 
-        documents.par_iter().for_each(|(doc_id, term_doc)| {
-            let weighted_tf = self.weighted_term_frequency(inverted_index, term_doc);
-            let score = self.score_weighted_tf(query_term.weight, idf, weighted_tf);
+        documents
+            .iter()
+            .par_bridge()
+            .for_each(|(doc_id, term_doc)| {
+                let weighted_tf = self.weighted_term_frequency(index, term_doc);
+                let score = self.score_weighted_tf(query_term.weight, idf, weighted_tf);
 
-            *scores.entry(*doc_id).or_insert(0.0) += score;
-        });
+                *scores.entry(doc_id).or_insert(0.0) += score;
+            });
     }
 }
 

--- a/crates/core/src/ranking/cosine_similarity.rs
+++ b/crates/core/src/ranking/cosine_similarity.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-
 use dashmap::DashMap;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{DocId, InvertedIndex, Term, TermDocument},
+    index::{DocId, PostingList, RankedIndexReader, Term},
     query::{AnalyzedQuery, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
@@ -12,22 +10,25 @@ use crate::{
 pub struct CosineSimilarity;
 
 impl Scorer for CosineSimilarity {
-    fn score(
+    fn score<I, P>(
         &self,
-        inverted_index: &InvertedIndex,
+        index: &I,
         query: &AnalyzedQuery,
         _: &Term,
         query_term: QueryTerm,
-        documents: &HashMap<DocId, TermDocument>,
+        documents: &P,
         scores: &DashMap<DocId, f64>,
-    ) {
-        let num_docs = inverted_index.num_docs();
+    ) where
+        I: RankedIndexReader + Sync,
+        P: PostingList + Sync,
+    {
+        let num_docs = index.num_docs();
 
         let query_magnitude = query
             .terms()
             .par_bridge()
             .map(|(term, query_term)| {
-                let idf = idf(num_docs, inverted_index.doc_freq(term));
+                let idf = idf(num_docs, index.doc_freq(term));
                 let weight = query_term.weight * idf;
                 weight * weight
             })
@@ -43,7 +44,7 @@ impl Scorer for CosineSimilarity {
                 let tf = term_doc.term_freq as f64;
                 let dot_product = query_term.weight * tf * term_idf * term_idf;
 
-                let Some(doc_magnitude) = inverted_index.document_norm(*doc_id) else {
+                let Some(doc_magnitude) = index.document_norm(doc_id) else {
                     return;
                 };
 
@@ -53,7 +54,7 @@ impl Scorer for CosineSimilarity {
 
                 let cosine_similarity = dot_product / (query_magnitude * doc_magnitude);
 
-                *scores.entry(*doc_id).or_insert(0.0) += cosine_similarity;
+                *scores.entry(doc_id).or_insert(0.0) += cosine_similarity;
             });
     }
 }

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -4,7 +4,7 @@ use dashmap::DashMap;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{DocId, DocumentField, InvertedIndex, Term, TermDocument},
+    index::{DocId, DocumentField, PostingList, RankedIndexReader, Term, TermDocument},
     query::{AnalyzedQuery, QueryTerm},
     ranking::{
         BM25, BM25F, BM25FHyperParams, BM25HyperParams, CosineSimilarity, FieldContribution,
@@ -49,53 +49,61 @@ pub enum RankingAlgo {
 }
 
 pub trait RankingAlgorithm {
-    fn score(&self, inverted_index: &InvertedIndex, query: &AnalyzedQuery) -> Scored;
+    fn score<I>(&self, index: &I, query: &AnalyzedQuery) -> Scored
+    where
+        I: RankedIndexReader + Sync;
 }
 
 pub trait Scorer: Send + Sync {
-    fn score(
+    fn score<I, P>(
         &self,
-        inverted_index: &InvertedIndex,
+        index: &I,
         query: &AnalyzedQuery,
         term: &Term,
         query_term: QueryTerm,
-        documents: &HashMap<DocId, TermDocument>,
+        documents: &P,
         scores: &DashMap<DocId, f64>,
-    );
+    ) where
+        I: RankedIndexReader + Sync,
+        P: PostingList + Sync;
 }
 
 impl RankingAlgorithm for RankingAlgo {
-    fn score(&self, inverted_index: &InvertedIndex, query: &AnalyzedQuery) -> Scored {
+    fn score<I>(&self, index: &I, query: &AnalyzedQuery) -> Scored
+    where
+        I: RankedIndexReader + Sync,
+    {
         match self {
-            RankingAlgo::CosineSimilarity => score_with(CosineSimilarity, inverted_index, query),
+            RankingAlgo::CosineSimilarity => score_with(CosineSimilarity, index, query),
             RankingAlgo::BM25(hyper_params) => score_with(
                 BM25 {
                     hyper_params: hyper_params.clone(),
                 },
-                inverted_index,
+                index,
                 query,
             ),
             RankingAlgo::BM25F(hyper_params) => score_with(
                 BM25F {
                     hyper_params: hyper_params.clone(),
                 },
-                inverted_index,
+                index,
                 query,
             ),
-            RankingAlgo::TFIDF => score_with(TFIDF, inverted_index, query),
+            RankingAlgo::TFIDF => score_with(TFIDF, index, query),
         }
     }
 }
 
-fn score_with<S>(scorer: S, inverted_index: &InvertedIndex, query: &AnalyzedQuery) -> Scored
+fn score_with<S, I>(scorer: S, index: &I, query: &AnalyzedQuery) -> Scored
 where
     S: Scorer,
+    I: RankedIndexReader + Sync,
 {
     let scores = DashMap::new();
 
     query.terms().par_bridge().for_each(|(term, query_term)| {
-        if let Some(documents) = inverted_index.get_postings(term) {
-            scorer.score(inverted_index, query, term, *query_term, documents, &scores)
+        if let Some(documents) = index.postings(term) {
+            scorer.score(index, query, term, *query_term, &documents, &scores)
         }
     });
 
@@ -104,7 +112,7 @@ where
             .iter()
             .par_bridge()
             .filter_map(|score| {
-                inverted_index.document(*score.key()).map(|metadata| Score {
+                index.document(*score.key()).map(|metadata| Score {
                     doc_path: metadata.path.clone(),
                     score: *score.value(),
                 })
@@ -114,17 +122,15 @@ where
 }
 
 impl RankingAlgo {
-    pub fn rank(
-        &self,
-        inverted_index: &InvertedIndex,
-        query: &AnalyzedQuery,
-        top_n: usize,
-    ) -> Option<Scored> {
+    pub fn rank<I>(&self, index: &I, query: &AnalyzedQuery, top_n: usize) -> Option<Scored>
+    where
+        I: RankedIndexReader + Sync,
+    {
         if query.is_empty() {
             return None;
         }
 
-        let mut ranking = self.score(inverted_index, query).0;
+        let mut ranking = self.score(index, query).0;
 
         ranking.sort_by(|a, b| b.score.total_cmp(&a.score));
         ranking.truncate(top_n);
@@ -136,20 +142,23 @@ impl RankingAlgo {
         }
     }
 
-    pub fn rank_with_explanations(
+    pub fn rank_with_explanations<I>(
         &self,
-        inverted_index: &InvertedIndex,
+        index: &I,
         query: &AnalyzedQuery,
         top_n: usize,
-    ) -> Option<ScoredWithExplanations> {
-        let ranked = self.rank(inverted_index, query, top_n)?;
+    ) -> Option<ScoredWithExplanations>
+    where
+        I: RankedIndexReader + Sync,
+    {
+        let ranked = self.rank(index, query, top_n)?;
         let results = ranked
             .0
             .into_iter()
             .filter_map(|score| {
-                let doc_id = inverted_index.doc_id(&score.doc_path)?;
+                let doc_id = index.doc_id(&score.doc_path)?;
                 Some(ScoreWithExplanation {
-                    explanation: self.explain_doc(inverted_index, query, doc_id, score.score),
+                    explanation: self.explain_doc(index, query, doc_id, score.score),
                     score,
                 })
             })
@@ -158,22 +167,21 @@ impl RankingAlgo {
         Some(ScoredWithExplanations { results })
     }
 
-    fn explain_doc(
+    fn explain_doc<I>(
         &self,
-        inverted_index: &InvertedIndex,
+        index: &I,
         query: &AnalyzedQuery,
         doc_id: DocId,
         final_score: f64,
-    ) -> ScoreExplanation {
+    ) -> ScoreExplanation
+    where
+        I: RankedIndexReader + Sync,
+    {
         let terms = match self {
-            RankingAlgo::BM25(hyper_params) => {
-                explain_bm25(inverted_index, query, doc_id, hyper_params)
-            }
-            RankingAlgo::BM25F(hyper_params) => {
-                explain_bm25f(inverted_index, query, doc_id, hyper_params)
-            }
+            RankingAlgo::BM25(hyper_params) => explain_bm25(index, query, doc_id, hyper_params),
+            RankingAlgo::BM25F(hyper_params) => explain_bm25f(index, query, doc_id, hyper_params),
             RankingAlgo::CosineSimilarity | RankingAlgo::TFIDF => {
-                explain_matched_terms(inverted_index, query, doc_id)
+                explain_matched_terms(index, query, doc_id)
             }
         };
 
@@ -185,23 +193,26 @@ impl RankingAlgo {
     }
 }
 
-fn explain_bm25(
-    inverted_index: &InvertedIndex,
+fn explain_bm25<I>(
+    index: &I,
     query: &AnalyzedQuery,
     doc_id: DocId,
     hyper_params: &BM25HyperParams,
-) -> Vec<TermExplanation> {
+) -> Vec<TermExplanation>
+where
+    I: RankedIndexReader + Sync,
+{
     let scorer = BM25 {
         hyper_params: hyper_params.clone(),
     };
-    let avgdl = inverted_index.avg_doc_length();
-    let num_docs = inverted_index.num_docs();
+    let avgdl = index.avg_doc_length();
+    let num_docs = index.num_docs();
 
     query
         .terms()
         .filter_map(|(term, query_term)| {
-            let documents = inverted_index.get_postings(term)?;
-            let term_doc = documents.get(&doc_id)?;
+            let documents = index.postings(term)?;
+            let term_doc = documents.get(doc_id)?;
             let term_idf = idf(num_docs, documents.len());
             let contribution = scorer.score_term(
                 query_term.weight,
@@ -224,22 +235,21 @@ fn explain_bm25(
         .collect()
 }
 
-fn explain_matched_terms(
-    inverted_index: &InvertedIndex,
-    query: &AnalyzedQuery,
-    doc_id: DocId,
-) -> Vec<TermExplanation> {
+fn explain_matched_terms<I>(index: &I, query: &AnalyzedQuery, doc_id: DocId) -> Vec<TermExplanation>
+where
+    I: RankedIndexReader + Sync,
+{
     query
         .terms()
         .filter_map(|(term, query_term)| {
-            let documents = inverted_index.get_postings(term)?;
-            let term_doc = documents.get(&doc_id)?;
+            let documents = index.postings(term)?;
+            let term_doc = documents.get(doc_id)?;
             Some(TermExplanation {
                 term: term.0.clone(),
                 query_weight: query_term.weight,
                 term_frequency: term_doc.term_freq,
                 document_frequency: documents.len(),
-                idf: idf(inverted_index.num_docs(), documents.len()),
+                idf: idf(index.num_docs(), documents.len()),
                 matched_fields: field_contributions(term_doc, 0.0),
                 contribution: 0.0,
             })
@@ -247,24 +257,27 @@ fn explain_matched_terms(
         .collect()
 }
 
-fn explain_bm25f(
-    inverted_index: &InvertedIndex,
+fn explain_bm25f<I>(
+    index: &I,
     query: &AnalyzedQuery,
     doc_id: DocId,
     hyper_params: &BM25FHyperParams,
-) -> Vec<TermExplanation> {
+) -> Vec<TermExplanation>
+where
+    I: RankedIndexReader + Sync,
+{
     let scorer = BM25F {
         hyper_params: hyper_params.clone(),
     };
-    let num_docs = inverted_index.num_docs();
+    let num_docs = index.num_docs();
 
     query
         .terms()
         .filter_map(|(term, query_term)| {
-            let documents = inverted_index.get_postings(term)?;
-            let term_doc = documents.get(&doc_id)?;
+            let documents = index.postings(term)?;
+            let term_doc = documents.get(doc_id)?;
             let term_idf = idf(num_docs, documents.len());
-            let weighted_tf = scorer.weighted_term_frequency(inverted_index, term_doc);
+            let weighted_tf = scorer.weighted_term_frequency(index, term_doc);
             let contribution = scorer.score_weighted_tf(query_term.weight, term_idf, weighted_tf);
 
             Some(TermExplanation {
@@ -353,9 +366,61 @@ mod tests {
     use super::{BM25HyperParams, RankingAlgo};
     use crate::{
         config::Config,
-        index::{DocumentField, InvertedIndex, Term},
+        index::{
+            DocId, DocumentField, DocumentMetadata, InvertedIndex, OwnedPostingList, PostingList,
+            RankedIndexReader, Term, TermDocument,
+        },
         query::AnalyzedQuery,
+        tokenizer::FileType,
     };
+
+    struct OwnedPostingsReader {
+        postings: HashMap<Term, OwnedPostingList>,
+        documents: HashMap<DocId, DocumentMetadata>,
+    }
+
+    impl RankedIndexReader for OwnedPostingsReader {
+        type Postings<'a> = OwnedPostingList;
+
+        fn postings(&self, term: &Term) -> Option<Self::Postings<'_>> {
+            self.postings.get(term).cloned()
+        }
+
+        fn document(&self, id: DocId) -> Option<&DocumentMetadata> {
+            self.documents.get(&id)
+        }
+
+        fn doc_id(&self, path: &Path) -> Option<DocId> {
+            self.documents
+                .iter()
+                .find_map(|(doc_id, metadata)| (metadata.path == path).then_some(*doc_id))
+        }
+
+        fn document_norm(&self, _: DocId) -> Option<f64> {
+            None
+        }
+
+        fn num_docs(&self) -> usize {
+            self.documents.len()
+        }
+
+        fn avg_doc_length(&self) -> f64 {
+            let total = self
+                .documents
+                .values()
+                .map(|metadata| metadata.token_length)
+                .sum::<usize>();
+            total as f64 / self.documents.len() as f64
+        }
+
+        fn avg_field_length(&self, _: DocumentField) -> f64 {
+            0.0
+        }
+
+        fn doc_freq(&self, term: &Term) -> usize {
+            self.postings.get(term).map_or(0, |postings| postings.len())
+        }
+    }
 
     fn index() -> InvertedIndex {
         InvertedIndex::from_documents(&[
@@ -395,6 +460,51 @@ mod tests {
             std::fs::create_dir_all(parent).unwrap();
         }
         std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn ranking_uses_reader_trait_with_owned_posting_lists() {
+        let rust = Term("rust".to_string());
+        let first = DocId::from_u32(0);
+        let second = DocId::from_u32(1);
+        let reader = OwnedPostingsReader {
+            postings: HashMap::from([(
+                rust.clone(),
+                OwnedPostingList::new(vec![
+                    (first, TermDocument::unfielded(2, 2)),
+                    (second, TermDocument::unfielded(2, 1)),
+                ]),
+            )]),
+            documents: HashMap::from([
+                (
+                    first,
+                    DocumentMetadata {
+                        id: first,
+                        path: PathBuf::from("first.rs"),
+                        token_length: 2,
+                        file_size_bytes: 10,
+                        file_type: FileType::Rust,
+                        field_lengths: HashMap::new(),
+                    },
+                ),
+                (
+                    second,
+                    DocumentMetadata {
+                        id: second,
+                        path: PathBuf::from("second.rs"),
+                        token_length: 2,
+                        file_size_bytes: 10,
+                        file_type: FileType::Rust,
+                        field_lengths: HashMap::new(),
+                    },
+                ),
+            ]),
+        };
+        let query = AnalyzedQuery::from_frequencies("rust", HashMap::from([(rust, 1)]));
+
+        let ranked = bm25().rank(&reader, &query, 2).unwrap();
+
+        assert_eq!(ranked.0[0].doc_path, PathBuf::from("first.rs"));
     }
 
     #[test]

--- a/crates/core/src/ranking/tf_idf.rs
+++ b/crates/core/src/ranking/tf_idf.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-
 use dashmap::DashMap;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
-    index::{DocId, InvertedIndex, Term, TermDocument},
+    index::{DocId, PostingList, RankedIndexReader, Term},
     query::{AnalyzedQuery, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
@@ -12,16 +10,19 @@ use crate::{
 pub struct TFIDF;
 
 impl Scorer for TFIDF {
-    fn score(
+    fn score<I, P>(
         &self,
-        inverted_index: &InvertedIndex,
+        index: &I,
         _: &AnalyzedQuery,
         _: &Term,
         query_term: QueryTerm,
-        documents: &HashMap<DocId, TermDocument>,
+        documents: &P,
         scores: &DashMap<DocId, f64>,
-    ) {
-        let num_docs = inverted_index.num_docs();
+    ) where
+        I: RankedIndexReader + Sync,
+        P: PostingList + Sync,
+    {
+        let num_docs = index.num_docs();
 
         documents
             .iter()
@@ -30,7 +31,7 @@ impl Scorer for TFIDF {
                 let tf = term_doc.term_freq as f64 / term_doc.length as f64;
                 let idf = idf(num_docs, documents.len());
 
-                *scores.entry(*doc_id).or_insert(0.0) += query_term.weight * tf * idf;
+                *scores.entry(doc_id).or_insert(0.0) += query_term.weight * tf * idf;
             });
     }
 }


### PR DESCRIPTION
- add shared/exclusive index access through `SearchEngine` so searches can run concurrently while updates remain isolated
- introduce persistent `snapshot` storage with schema/config/source validation plus replayable `IndexEvent` logs for incremental updates
- finish `DocId`-ordered ranked postings and add compressed posting storage with v-byte encoding and skip metadata
- add a lexicon-backed inverted-file layout so index metadata can warm-start before individual posting lists are decoded
- keep ranked search behavior covered through storage, replay, compression, skip, and snapshot round-trip tests