### PR TITLE
feat(search): add production relevance signals

### DIFF
--- a/crates/cli/src/eval.rs
+++ b/crates/cli/src/eval.rs
@@ -1,8 +1,6 @@
 use std::{
-    collections::BTreeMap,
     fs::{self, File},
-    io::Write,
-    path::{Path, PathBuf},
+    path::Path,
     process::Command as ProcessCommand,
 };
 
@@ -20,7 +18,7 @@ use repo_reaper_core::{
     query::QueryExpansionConfig,
     ranking::{
         RankingAlgo,
-        features::{PairwisePreferenceRow, RankingFeatureRow},
+        features::{JsonlFeatureSink, export_evaluation_features_to_sink},
     },
     tokenizer::n_gram_transform,
 };
@@ -313,13 +311,6 @@ fn read_evaluation_baseline(path: &Path) -> Result<EvaluationReport> {
     })
 }
 
-#[derive(serde::Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum FeatureExportRecord {
-    Feature(RankingFeatureRow),
-    PairwisePreference(PairwisePreferenceRow),
-}
-
 fn write_feature_export(
     path: &Path,
     inverted_index: &InvertedIndex,
@@ -327,45 +318,17 @@ fn write_feature_export(
     evaluation_data: &EvaluationData,
     top_n: usize,
 ) -> Result<()> {
-    let mut file = File::create(path)
+    let file = File::create(path)
         .with_context(|| format!("failed to create feature export at {}", path.display()))?;
-
-    for (index, example) in evaluation_data.examples.iter().enumerate() {
-        let query_id = format!("q{}", index + 1);
-        let relevance = example
-            .results
-            .iter()
-            .filter_map(|result| match &result.relevance {
-                Relevance::Relevant(rank) => Some((result.path.clone(), *rank)),
-                Relevance::NonRelevant => None,
-            })
-            .collect::<BTreeMap<PathBuf, usize>>();
-
-        for row in repo_reaper_core::ranking::features::export_feature_rows(
-            inverted_index,
-            ranking_algorithm,
-            &query_id,
-            &example.query,
-            top_n,
-            &relevance,
-        ) {
-            write_jsonl(&mut file, &FeatureExportRecord::Feature(row))?;
-        }
-
-        for row in
-            repo_reaper_core::ranking::features::export_pairwise_preferences(&query_id, &relevance)
-        {
-            write_jsonl(&mut file, &FeatureExportRecord::PairwisePreference(row))?;
-        }
-    }
-
-    Ok(())
-}
-
-fn write_jsonl(file: &mut File, record: &FeatureExportRecord) -> Result<()> {
-    serde_json::to_writer(&mut *file, record).context("failed to serialize feature record")?;
-    file.write_all(b"\n")
-        .context("failed to write feature record")?;
+    let mut sink = JsonlFeatureSink::new(file);
+    export_evaluation_features_to_sink(
+        &mut sink,
+        inverted_index,
+        ranking_algorithm,
+        evaluation_data,
+        top_n,
+    )
+    .context("failed to write feature export")?;
     Ok(())
 }
 

--- a/crates/cli/src/eval.rs
+++ b/crates/cli/src/eval.rs
@@ -1,4 +1,10 @@
-use std::{fs, path::Path, process::Command as ProcessCommand};
+use std::{
+    collections::BTreeMap,
+    fs::{self, File},
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command as ProcessCommand,
+};
 
 use anyhow::{Context, Result, bail};
 use clap::ValueEnum;
@@ -11,6 +17,11 @@ use repo_reaper_core::{
         metrics::{GroundednessResult, TestQuery, TokenEfficiencyEvaluation},
     },
     index::InvertedIndex,
+    query::QueryExpansionConfig,
+    ranking::{
+        RankingAlgo,
+        features::{PairwisePreferenceRow, RankingFeatureRow},
+    },
     tokenizer::n_gram_transform,
 };
 
@@ -95,10 +106,14 @@ pub(crate) fn evaluate_training(args: &crate::Args, config: &ReaperConfig) -> Re
     let raw_evaluation_data: RawEvaluationData = serde_json::from_str(&file_content)
         .context("failed to deserialize evaluation JSON data")?;
 
-    let evaluation_data = EvaluationData::parse_with_code_search(
+    let evaluation_data = EvaluationData::parse_with_options(
         raw_evaluation_data,
         config,
         args.ranking_algorithm.needs_fielded_index(),
+        QueryExpansionConfig {
+            controlled: args.query_expansion,
+            feedback: args.feedback_expansion,
+        },
     )
     .context("failed to parse evaluation data")?;
 
@@ -184,8 +199,19 @@ pub(crate) fn evaluate_training(args: &crate::Args, config: &ReaperConfig) -> Re
     let evaluation_report = TestSet {
         ranking_algorithm: args.ranking_algorithm.clone(),
         queries,
+        feedback_expansion: args.feedback_expansion,
     }
     .evaluate_report(&inverted_index, args.top_n);
+
+    if let Some(path) = &args.export_features {
+        write_feature_export(
+            path,
+            &inverted_index,
+            &args.ranking_algorithm,
+            &evaluation_data,
+            args.top_n,
+        )?;
+    }
 
     if let Some(baseline_path) = &args.eval_compare {
         let baseline = read_evaluation_baseline(baseline_path)?;
@@ -285,6 +311,62 @@ fn read_evaluation_baseline(path: &Path) -> Result<EvaluationReport> {
             token_efficiency: TokenEfficiencyEvaluation::default(),
         },
     })
+}
+
+#[derive(serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum FeatureExportRecord {
+    Feature(RankingFeatureRow),
+    PairwisePreference(PairwisePreferenceRow),
+}
+
+fn write_feature_export(
+    path: &Path,
+    inverted_index: &InvertedIndex,
+    ranking_algorithm: &RankingAlgo,
+    evaluation_data: &EvaluationData,
+    top_n: usize,
+) -> Result<()> {
+    let mut file = File::create(path)
+        .with_context(|| format!("failed to create feature export at {}", path.display()))?;
+
+    for (index, example) in evaluation_data.examples.iter().enumerate() {
+        let query_id = format!("q{}", index + 1);
+        let relevance = example
+            .results
+            .iter()
+            .filter_map(|result| match &result.relevance {
+                Relevance::Relevant(rank) => Some((result.path.clone(), *rank)),
+                Relevance::NonRelevant => None,
+            })
+            .collect::<BTreeMap<PathBuf, usize>>();
+
+        for row in repo_reaper_core::ranking::features::export_feature_rows(
+            inverted_index,
+            ranking_algorithm,
+            &query_id,
+            &example.query,
+            top_n,
+            &relevance,
+        ) {
+            write_jsonl(&mut file, &FeatureExportRecord::Feature(row))?;
+        }
+
+        for row in
+            repo_reaper_core::ranking::features::export_pairwise_preferences(&query_id, &relevance)
+        {
+            write_jsonl(&mut file, &FeatureExportRecord::PairwisePreference(row))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_jsonl(file: &mut File, record: &FeatureExportRecord) -> Result<()> {
+    serde_json::to_writer(&mut *file, record).context("failed to serialize feature record")?;
+    file.write_all(b"\n")
+        .context("failed to write feature record")?;
+    Ok(())
 }
 
 fn compare_evaluation_reports(

--- a/crates/cli/src/live_search.rs
+++ b/crates/cli/src/live_search.rs
@@ -14,8 +14,11 @@ use notify::{
     event::{ModifyKind, RemoveKind},
 };
 use repo_reaper_core::{
-    config::Config as ReaperConfig, index::InvertedIndex, query::AnalyzedQuery,
-    ranking::RankingAlgo, tokenizer::n_gram_transform,
+    config::Config as ReaperConfig,
+    index::InvertedIndex,
+    query::{AnalyzedQuery, QueryExpansionConfig},
+    ranking::RankingAlgo,
+    tokenizer::n_gram_transform,
 };
 
 pub(crate) fn run(
@@ -23,6 +26,8 @@ pub(crate) fn run(
     config: Arc<ReaperConfig>,
     algo: RankingAlgo,
     top_n: usize,
+    query_expansion: bool,
+    feedback_expansion: bool,
 ) -> Result<()> {
     let config_clone = Arc::clone(&config);
     let transformer = Arc::new(move |content: &str| n_gram_transform(content, &config_clone));
@@ -58,7 +63,14 @@ pub(crate) fn run(
         Arc::clone(&config),
         algo.needs_fielded_index(),
     );
-    run_repl(config, algo, top_n, inverted_index)
+    run_repl(
+        config,
+        algo,
+        top_n,
+        inverted_index,
+        query_expansion,
+        feedback_expansion,
+    )
 }
 
 fn spawn_watcher(
@@ -136,6 +148,8 @@ fn run_repl(
     algo: RankingAlgo,
     top_n: usize,
     inverted_index: Arc<Mutex<InvertedIndex>>,
+    query_expansion: bool,
+    feedback_expansion: bool,
 ) -> Result<()> {
     loop {
         println!("Enter a query: ");
@@ -150,7 +164,14 @@ fn run_repl(
         }
 
         let query = if algo.needs_fielded_index() {
-            AnalyzedQuery::new_code_search(&query, &config)
+            AnalyzedQuery::new_code_search_with_expansion(
+                &query,
+                &config,
+                QueryExpansionConfig {
+                    controlled: query_expansion,
+                    feedback: feedback_expansion,
+                },
+            )
         } else {
             AnalyzedQuery::new(&query, &config)
         };
@@ -159,7 +180,11 @@ fn run_repl(
             let index = inverted_index
                 .lock()
                 .map_err(|_| anyhow!("index lock poisoned"))?;
-            algo.rank(&index, &query, top_n)
+            if feedback_expansion {
+                algo.rank_with_feedback(&index, &query, top_n, top_n.min(3), 6)
+            } else {
+                algo.rank(&index, &query, top_n)
+            }
         };
 
         log_query(&query, &ranking, &algo, top_n)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -59,6 +59,15 @@ struct Args {
     /// Print corpus statistics for the indexed directory and exit
     #[clap(long, default_value = "false")]
     stats: bool,
+    /// Enable controlled abbreviation query expansion
+    #[clap(long, default_value = "false")]
+    query_expansion: bool,
+    /// Enable experimental pseudo-relevance feedback expansion
+    #[clap(long, default_value = "false")]
+    feedback_expansion: bool,
+    /// Write ranking feature export JSONL while evaluating
+    #[clap(long)]
+    export_features: Option<PathBuf>,
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -99,7 +108,14 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    live_search::run(args.directory, config, args.ranking_algorithm, args.top_n)
+    live_search::run(
+        args.directory,
+        config,
+        args.ranking_algorithm,
+        args.top_n,
+        args.query_expansion,
+        args.feedback_expansion,
+    )
 }
 
 fn print_directory_stats(directory: &Path, config: &ReaperConfig) {

--- a/crates/core/src/evaluation/dataset.rs
+++ b/crates/core/src/evaluation/dataset.rs
@@ -2,7 +2,11 @@ use std::path::PathBuf;
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-use crate::{config::Config, error::EvalError, query::AnalyzedQuery};
+use crate::{
+    config::Config,
+    error::EvalError,
+    query::{AnalyzedQuery, QueryExpansionConfig},
+};
 
 #[derive(serde::Deserialize, Debug)]
 pub struct RawEvaluationData {
@@ -28,12 +32,26 @@ impl EvaluationData {
         config: &Config,
         code_search_queries: bool,
     ) -> Result<Self, EvalError> {
+        Self::parse_with_options(
+            raw,
+            config,
+            code_search_queries,
+            QueryExpansionConfig::default(),
+        )
+    }
+
+    pub fn parse_with_options(
+        raw: RawEvaluationData,
+        config: &Config,
+        code_search_queries: bool,
+        expansion: QueryExpansionConfig,
+    ) -> Result<Self, EvalError> {
         let corpus = EvaluationCorpus::parse(raw.local_root, raw.repo, raw.repo_path, raw.commit)?;
 
         let examples: Result<Vec<_>, _> = raw
             .examples
             .into_par_iter()
-            .map(|example| Example::parse(example, config, code_search_queries))
+            .map(|example| Example::parse(example, config, code_search_queries, expansion))
             .collect();
 
         Ok(EvaluationData {
@@ -97,6 +115,7 @@ impl Example {
         raw: RawExample,
         config: &Config,
         code_search_query: bool,
+        expansion: QueryExpansionConfig,
     ) -> Result<Self, EvalError> {
         let results: Result<Vec<_>, _> = raw
             .results
@@ -104,7 +123,7 @@ impl Example {
             .map(ResultData::try_from)
             .collect();
         let query = if code_search_query {
-            AnalyzedQuery::new_code_search(&raw.query, config)
+            AnalyzedQuery::new_code_search_with_expansion(&raw.query, config, expansion)
         } else {
             AnalyzedQuery::new(&raw.query, config)
         };

--- a/crates/core/src/evaluation/metrics/report.rs
+++ b/crates/core/src/evaluation/metrics/report.rs
@@ -24,7 +24,15 @@ impl TestSet {
         let evaluated_queries: Vec<EvaluatedQuery> = self
             .queries
             .par_iter()
-            .map(|query| evaluate_query(&self.ranking_algorithm, inverted_index, query, top_n))
+            .map(|query| {
+                evaluate_query(
+                    &self.ranking_algorithm,
+                    inverted_index,
+                    query,
+                    top_n,
+                    self.feedback_expansion,
+                )
+            })
             .collect();
         let queries = evaluated_queries
             .iter()
@@ -91,11 +99,15 @@ fn evaluate_query(
     inverted_index: &InvertedIndex,
     query: &TestQuery,
     top_n: usize,
+    feedback_expansion: bool,
 ) -> EvaluatedQuery {
-    let ranked_docs = ranking_algorithm
-        .rank(inverted_index, &query.query, top_n)
-        .map(|ranking| ranking.0)
-        .unwrap_or_default();
+    let ranked_docs = if feedback_expansion {
+        ranking_algorithm.rank_with_feedback(inverted_index, &query.query, top_n, top_n.min(3), 6)
+    } else {
+        ranking_algorithm.rank(inverted_index, &query.query, top_n)
+    }
+    .map(|ranking| ranking.0)
+    .unwrap_or_default();
 
     let metrics = evaluate_query_at_k(&ranked_docs, &query.relevant_docs, top_n);
     let groundedness = evaluate_groundedness_at_k(&ranked_docs, &query.groundedness_results, top_n);

--- a/crates/core/src/evaluation/metrics/tests.rs
+++ b/crates/core/src/evaluation/metrics/tests.rs
@@ -403,6 +403,7 @@ fn evaluate_report_includes_query_metrics_and_evidence_boundary() {
     let test_set = TestSet {
         ranking_algorithm: RankingAlgo::TFIDF,
         queries,
+        feedback_expansion: false,
     };
     let temp = tempfile::tempdir().unwrap();
     let index =

--- a/crates/core/src/evaluation/metrics/types.rs
+++ b/crates/core/src/evaluation/metrics/types.rs
@@ -10,6 +10,7 @@ use crate::{
 pub struct TestSet {
     pub ranking_algorithm: RankingAlgo,
     pub queries: Vec<TestQuery>,
+    pub feedback_expansion: bool,
 }
 
 pub struct TestQuery {

--- a/crates/core/src/index/document_registry.rs
+++ b/crates/core/src/index/document_registry.rs
@@ -3,7 +3,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{index::DocumentField, tokenizer::FileType};
+use crate::{
+    index::{DocumentField, StaticQualitySignals},
+    tokenizer::FileType,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DocId(u32);
@@ -26,10 +29,12 @@ pub struct DocumentMetadata {
     pub file_size_bytes: u64,
     pub file_type: FileType,
     pub field_lengths: HashMap<DocumentField, usize>,
+    pub quality_signals: StaticQualitySignals,
 }
 
 impl DocumentMetadata {
     fn new(id: DocId, path: PathBuf, token_length: usize, file_size_bytes: u64) -> Self {
+        let quality_signals = StaticQualitySignals::analyze(&path, "", file_size_bytes);
         Self::new_with_fields(
             id,
             path,
@@ -37,6 +42,7 @@ impl DocumentMetadata {
             file_size_bytes,
             FileType::UnknownText,
             HashMap::new(),
+            quality_signals,
         )
     }
 
@@ -47,6 +53,7 @@ impl DocumentMetadata {
         file_size_bytes: u64,
         file_type: FileType,
         field_lengths: HashMap<DocumentField, usize>,
+        quality_signals: StaticQualitySignals,
     ) -> Self {
         Self {
             id,
@@ -55,6 +62,7 @@ impl DocumentMetadata {
             file_size_bytes,
             file_type,
             field_lengths,
+            quality_signals,
         }
     }
 
@@ -85,8 +93,9 @@ pub trait DocumentCatalog {
         file_size_bytes: u64,
         file_type: FileType,
         field_lengths: HashMap<DocumentField, usize>,
+        quality_signals: StaticQualitySignals,
     ) -> DocId {
-        let _ = (file_type, field_lengths);
+        let _ = (file_type, field_lengths, quality_signals);
         self.insert_or_update(path, token_length, file_size_bytes)
     }
     fn remove(&mut self, path: &Path) -> Option<DocumentMetadata>;
@@ -138,6 +147,7 @@ impl DocumentCatalog for DocumentRegistry {
         file_size_bytes: u64,
         file_type: FileType,
         field_lengths: HashMap<DocumentField, usize>,
+        quality_signals: StaticQualitySignals,
     ) -> DocId {
         if let Some(&id) = self.path_to_id.get(&path) {
             if let Some(existing) = self.documents.get_mut(&id) {
@@ -150,6 +160,7 @@ impl DocumentCatalog for DocumentRegistry {
                     file_size_bytes,
                     file_type,
                     field_lengths,
+                    quality_signals,
                 );
             }
             return id;
@@ -164,6 +175,7 @@ impl DocumentCatalog for DocumentRegistry {
             file_size_bytes,
             file_type,
             field_lengths,
+            quality_signals,
         );
         self.path_to_id.insert(metadata.path.clone(), id);
         self.total_token_length += token_length as u64;

--- a/crates/core/src/index/inverted_index.rs
+++ b/crates/core/src/index/inverted_index.rs
@@ -9,6 +9,7 @@ use crate::{
         corpus::{FileSystemIndexCorpus, IndexCorpus, IndexCorpusDocument, SkippedDocument},
         document_registry::{DocId, DocumentCatalog, DocumentMetadata, DocumentRegistry},
         field::DocumentField,
+        quality::StaticQualitySignals,
         term::Term,
     },
     ranking::idf,
@@ -92,6 +93,7 @@ struct ProcessedDocument {
     token_length: usize,
     file_size_bytes: u64,
     file_type: FileType,
+    quality_signals: StaticQualitySignals,
 }
 
 #[cfg(test)]
@@ -251,6 +253,7 @@ where
             0,
             document.file_type,
             document.field_lengths.clone(),
+            document.quality_signals.clone(),
         );
         Self::postings_for_document(doc_id, &document)
     }
@@ -270,6 +273,11 @@ where
             token_length,
             file_size_bytes: document.file_size_bytes,
             file_type: FileType::UnknownText,
+            quality_signals: StaticQualitySignals::analyze(
+                &document.path,
+                &document.content,
+                document.file_size_bytes,
+            ),
         }
     }
 
@@ -316,6 +324,11 @@ where
             token_length,
             file_size_bytes: document.file_size_bytes,
             file_type,
+            quality_signals: StaticQualitySignals::analyze(
+                &document.path,
+                &document.content,
+                document.file_size_bytes,
+            ),
         }
     }
 
@@ -360,6 +373,7 @@ where
             document.file_size_bytes,
             document.file_type,
             document.field_lengths.clone(),
+            document.quality_signals.clone(),
         );
 
         for (term, doc_map) in Self::postings_for_document(doc_id, &document) {

--- a/crates/core/src/index/mod.rs
+++ b/crates/core/src/index/mod.rs
@@ -2,6 +2,7 @@ pub mod corpus;
 pub mod document_registry;
 pub mod field;
 pub mod inverted_index;
+pub mod quality;
 pub mod term;
 
 pub use corpus::{
@@ -14,4 +15,5 @@ pub use inverted_index::{
     CorpusStats, IndexBuildReport, IndexBuildResult, InvertedIndex, TermDocument,
     TermFrequencySummary,
 };
+pub use quality::StaticQualitySignals;
 pub use term::Term;

--- a/crates/core/src/index/quality.rs
+++ b/crates/core/src/index/quality.rs
@@ -1,0 +1,247 @@
+use std::{
+    collections::HashMap,
+    path::{Component, Path},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct StaticQualitySignals {
+    pub file_depth: usize,
+    pub file_size_bytes: u64,
+    pub generated: bool,
+    pub vendor: bool,
+    pub test: bool,
+    pub entry_point: bool,
+    pub readme: bool,
+    pub config_or_manifest: bool,
+    pub public_entry_point: bool,
+    pub reference_count: usize,
+}
+
+impl StaticQualitySignals {
+    pub fn analyze(path: &Path, content: &str, file_size_bytes: u64) -> Self {
+        let normalized_path = path
+            .to_string_lossy()
+            .replace('\\', "/")
+            .to_ascii_lowercase();
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        let file_depth = path
+            .components()
+            .filter(|component| matches!(component, Component::Normal(_)))
+            .count()
+            .saturating_sub(1);
+        let generated = is_generated(&normalized_path, content);
+        let vendor = is_vendor_path(&normalized_path);
+        let test = is_test_path(&normalized_path, &file_name);
+        let entry_point = is_entry_point(&normalized_path, &file_name);
+        let readme = file_name == "readme.md" || file_name == "readme";
+        let config_or_manifest = is_config_or_manifest(&file_name);
+        let public_entry_point = is_public_entry_point(content);
+        let reference_count = approximate_reference_count(content);
+
+        Self {
+            file_depth,
+            file_size_bytes,
+            generated,
+            vendor,
+            test,
+            entry_point,
+            readme,
+            config_or_manifest,
+            public_entry_point,
+            reference_count,
+        }
+    }
+
+    pub fn prior_score(&self) -> f64 {
+        let mut score = 0.0;
+
+        if self.generated {
+            score -= 0.55;
+        }
+        if self.vendor {
+            score -= 0.45;
+        }
+        if self.test {
+            score -= 0.08;
+        }
+        if self.entry_point {
+            score += 0.28;
+        }
+        if self.readme {
+            score += 0.22;
+        }
+        if self.config_or_manifest {
+            score += 0.20;
+        }
+        if self.public_entry_point {
+            score += 0.12;
+        }
+
+        score += match self.file_depth {
+            0 | 1 => 0.10,
+            2 => 0.04,
+            3..=5 => 0.0,
+            _ => -0.08,
+        };
+
+        if self.file_size_bytes > 750_000 {
+            score -= 0.18;
+        } else if self.file_size_bytes > 250_000 {
+            score -= 0.08;
+        }
+
+        score + (self.reference_count.min(12) as f64 * 0.015)
+    }
+
+    pub fn features(&self) -> HashMap<&'static str, f64> {
+        HashMap::from([
+            ("file_depth", self.file_depth as f64),
+            ("file_size_bytes", self.file_size_bytes as f64),
+            ("generated", bool_feature(self.generated)),
+            ("vendor", bool_feature(self.vendor)),
+            ("test", bool_feature(self.test)),
+            ("entry_point", bool_feature(self.entry_point)),
+            ("readme", bool_feature(self.readme)),
+            ("config_or_manifest", bool_feature(self.config_or_manifest)),
+            ("public_entry_point", bool_feature(self.public_entry_point)),
+            ("reference_count", self.reference_count as f64),
+            ("static_prior_score", self.prior_score()),
+        ])
+    }
+}
+
+fn bool_feature(value: bool) -> f64 {
+    if value { 1.0 } else { 0.0 }
+}
+
+fn is_generated(normalized_path: &str, content: &str) -> bool {
+    normalized_path.contains("/generated/")
+        || normalized_path.contains("/gen/")
+        || normalized_path.ends_with(".generated.rs")
+        || normalized_path.ends_with(".pb.go")
+        || normalized_path.ends_with(".pb.rs")
+        || content
+            .lines()
+            .take(8)
+            .any(|line| line.to_ascii_lowercase().contains("generated"))
+}
+
+fn is_vendor_path(normalized_path: &str) -> bool {
+    normalized_path.contains("/vendor/")
+        || normalized_path.starts_with("vendor/")
+        || normalized_path.contains("/node_modules/")
+        || normalized_path.starts_with("node_modules/")
+        || normalized_path.contains("/third_party/")
+        || normalized_path.starts_with("third_party/")
+        || normalized_path.contains("/target/")
+        || normalized_path.starts_with("target/")
+        || normalized_path.contains("/dist/")
+        || normalized_path.starts_with("dist/")
+        || normalized_path.contains("/build/")
+        || normalized_path.starts_with("build/")
+}
+
+fn is_test_path(normalized_path: &str, file_name: &str) -> bool {
+    normalized_path.contains("/tests/")
+        || normalized_path.contains("/test/")
+        || file_name.starts_with("test_")
+        || file_name.ends_with("_test.rs")
+        || file_name.ends_with("_test.go")
+        || file_name.ends_with(".test.ts")
+        || file_name.ends_with(".spec.ts")
+}
+
+fn is_entry_point(normalized_path: &str, file_name: &str) -> bool {
+    matches!(
+        file_name,
+        "main.rs" | "lib.rs" | "mod.rs" | "main.py" | "index.ts" | "index.js" | "main.go"
+    ) || normalized_path == "src/main.rs"
+        || normalized_path == "src/lib.rs"
+}
+
+fn is_config_or_manifest(file_name: &str) -> bool {
+    matches!(
+        file_name,
+        "cargo.toml"
+            | "pyproject.toml"
+            | "package.json"
+            | "tsconfig.json"
+            | "dockerfile"
+            | "makefile"
+            | "justfile"
+            | "readme.md"
+    ) || file_name.ends_with(".yaml")
+        || file_name.ends_with(".yml")
+        || file_name.ends_with(".toml")
+        || file_name.ends_with(".json")
+}
+
+fn is_public_entry_point(content: &str) -> bool {
+    content.lines().take(80).any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("pub fn main")
+            || trimmed.starts_with("fn main")
+            || trimmed.starts_with("pub mod ")
+            || trimmed.starts_with("pub struct ")
+            || trimmed.starts_with("pub enum ")
+            || trimmed.starts_with("export ")
+            || trimmed.starts_with("def main")
+    })
+}
+
+fn approximate_reference_count(content: &str) -> usize {
+    content
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("use ")
+                || trimmed.starts_with("pub use ")
+                || trimmed.starts_with("pub mod ")
+                || trimmed.starts_with("mod ")
+                || trimmed.starts_with("import ")
+                || trimmed.starts_with("from ")
+                || trimmed.starts_with("#include ")
+                || trimmed.starts_with("require(")
+        })
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::StaticQualitySignals;
+
+    #[test]
+    fn detects_generated_vendor_and_test_markers() {
+        let signals = StaticQualitySignals::analyze(
+            Path::new("vendor/generated/client_test.rs"),
+            "// generated by tool\nfn test_case() {}",
+            120,
+        );
+
+        assert!(signals.generated);
+        assert!(signals.vendor);
+        assert!(signals.test);
+        assert!(signals.prior_score() < 0.0);
+    }
+
+    #[test]
+    fn boosts_entry_points_manifests_and_reference_like_lines() {
+        let signals = StaticQualitySignals::analyze(
+            Path::new("src/lib.rs"),
+            "pub mod search;\nuse crate::search::Index;\npub struct Engine;",
+            90,
+        );
+
+        assert!(signals.entry_point);
+        assert!(signals.public_entry_point);
+        assert_eq!(signals.reference_count, 2);
+        assert!(signals.prior_score() > 0.0);
+    }
+}

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -9,6 +9,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct AnalyzedQuery {
     original_text: String,
+    intent: QueryIntent,
     terms: HashMap<Term, QueryTerm>,
 }
 
@@ -16,14 +17,51 @@ pub struct AnalyzedQuery {
 pub struct QueryTerm {
     pub frequency: u32,
     pub weight: f64,
+    pub provenance: QueryTermProvenance,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryIntent {
+    Path,
+    Identifier,
+    NaturalLanguage,
+    ErrorMessage,
+    Config,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueryTermProvenance {
+    Original,
+    ControlledExpansion,
+    Feedback,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct QueryExpansionConfig {
+    pub controlled: bool,
+    pub feedback: bool,
 }
 
 impl AnalyzedQuery {
     pub fn new(query: &str, config: &Config) -> Self {
-        Self::from_frequencies(query.to_string(), n_gram_transform(query, config))
+        Self::from_frequencies_with_intent(
+            query.to_string(),
+            classify_query_intent(query),
+            n_gram_transform(query, config),
+        )
     }
 
     pub fn new_code_search(query: &str, config: &Config) -> Self {
+        Self::new_code_search_with_expansion(query, config, QueryExpansionConfig::default())
+    }
+
+    pub fn new_code_search_with_expansion(
+        query: &str,
+        config: &Config,
+        expansion: QueryExpansionConfig,
+    ) -> Self {
+        let intent = classify_query_intent(query);
         let profile = AnalyzerProfile::for_file_type(FileType::Rust);
         let frequencies = profile
             .analyze(AnalyzerField::Content, query, config)
@@ -33,11 +71,30 @@ impl AnalyzedQuery {
                 acc
             });
 
-        Self::from_frequencies(query.to_string(), frequencies)
+        let mut query = Self::from_frequencies_with_intent(query.to_string(), intent, frequencies);
+        if expansion.controlled && query.intent.allows_controlled_expansion() {
+            let additions = controlled_expansions(query.terms.keys().map(|term| term.0.as_str()));
+            query.add_weighted_terms(additions, QueryTermProvenance::ControlledExpansion);
+        }
+
+        query
     }
 
     pub fn from_frequencies(
         original_text: impl Into<String>,
+        frequencies: HashMap<Term, u32>,
+    ) -> Self {
+        let original_text = original_text.into();
+        Self::from_frequencies_with_intent(
+            original_text.clone(),
+            classify_query_intent(&original_text),
+            frequencies,
+        )
+    }
+
+    pub fn from_frequencies_with_intent(
+        original_text: impl Into<String>,
+        intent: QueryIntent,
         frequencies: HashMap<Term, u32>,
     ) -> Self {
         let terms = frequencies
@@ -49,6 +106,7 @@ impl AnalyzedQuery {
                     QueryTerm {
                         frequency,
                         weight: frequency as f64,
+                        provenance: QueryTermProvenance::Original,
                     },
                 )
             })
@@ -56,11 +114,25 @@ impl AnalyzedQuery {
 
         Self {
             original_text: original_text.into(),
+            intent,
             terms,
         }
     }
 
     pub fn from_weights(original_text: impl Into<String>, weights: HashMap<Term, f64>) -> Self {
+        let original_text = original_text.into();
+        Self::from_weights_with_intent(
+            original_text.clone(),
+            classify_query_intent(&original_text),
+            weights,
+        )
+    }
+
+    pub fn from_weights_with_intent(
+        original_text: impl Into<String>,
+        intent: QueryIntent,
+        weights: HashMap<Term, f64>,
+    ) -> Self {
         let terms = weights
             .into_iter()
             .filter(|(_, weight)| *weight > 0.0)
@@ -70,6 +142,7 @@ impl AnalyzedQuery {
                     QueryTerm {
                         frequency: 1,
                         weight,
+                        provenance: QueryTermProvenance::Original,
                     },
                 )
             })
@@ -77,6 +150,7 @@ impl AnalyzedQuery {
 
         Self {
             original_text: original_text.into(),
+            intent,
             terms,
         }
     }
@@ -85,8 +159,16 @@ impl AnalyzedQuery {
         &self.original_text
     }
 
+    pub fn intent(&self) -> QueryIntent {
+        self.intent
+    }
+
     pub fn terms(&self) -> impl Iterator<Item = (&Term, &QueryTerm)> {
         self.terms.iter()
+    }
+
+    pub fn add_feedback_terms(&mut self, weights: HashMap<Term, f64>) {
+        self.add_weighted_terms(weights, QueryTermProvenance::Feedback);
     }
 
     pub fn is_empty(&self) -> bool {
@@ -96,6 +178,134 @@ impl AnalyzedQuery {
     pub fn len(&self) -> usize {
         self.terms.len()
     }
+
+    fn add_weighted_terms(&mut self, weights: HashMap<Term, f64>, provenance: QueryTermProvenance) {
+        for (term, weight) in weights {
+            if weight <= 0.0 {
+                continue;
+            }
+
+            self.terms
+                .entry(term)
+                .and_modify(|existing| existing.weight += weight)
+                .or_insert(QueryTerm {
+                    frequency: 1,
+                    weight,
+                    provenance,
+                });
+        }
+    }
+}
+
+impl QueryIntent {
+    pub fn allows_controlled_expansion(self) -> bool {
+        matches!(
+            self,
+            Self::NaturalLanguage | Self::ErrorMessage | Self::Config
+        )
+    }
+}
+
+impl QueryTermProvenance {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Original => "original",
+            Self::ControlledExpansion => "controlled_expansion",
+            Self::Feedback => "feedback",
+        }
+    }
+}
+
+pub fn classify_query_intent(query: &str) -> QueryIntent {
+    let trimmed = query.trim();
+    let lower = trimmed.to_ascii_lowercase();
+
+    if looks_config_like(trimmed, &lower) {
+        return QueryIntent::Config;
+    }
+    if looks_path_like(trimmed, &lower) {
+        return QueryIntent::Path;
+    }
+    if looks_error_like(trimmed, &lower) {
+        return QueryIntent::ErrorMessage;
+    }
+    if looks_identifier_like(trimmed) {
+        return QueryIntent::Identifier;
+    }
+
+    QueryIntent::NaturalLanguage
+}
+
+fn looks_path_like(query: &str, lower: &str) -> bool {
+    query.contains('/')
+        || query.contains('\\')
+        || lower.starts_with("./")
+        || lower.starts_with("../")
+        || lower.ends_with(".rs")
+        || lower.ends_with(".toml")
+        || lower.ends_with(".json")
+        || lower.ends_with(".yaml")
+        || lower.ends_with(".yml")
+}
+
+fn looks_identifier_like(query: &str) -> bool {
+    !query.contains(char::is_whitespace)
+        && query.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '_' || character == '-'
+        })
+        && query
+            .chars()
+            .any(|character| character == '_' || character == '-' || character.is_ascii_uppercase())
+}
+
+fn looks_error_like(query: &str, lower: &str) -> bool {
+    query.contains('"')
+        || lower.contains("error:")
+        || lower.contains("panic")
+        || lower.contains("failed to")
+        || lower.contains("exception")
+        || lower.contains("not found")
+        || query.split_whitespace().count() >= 6
+            && query
+                .chars()
+                .any(|character| matches!(character, ':' | '\'' | '`' | '(' | ')'))
+}
+
+fn looks_config_like(query: &str, lower: &str) -> bool {
+    lower.contains("cargo.toml")
+        || lower.contains("package.json")
+        || lower.contains("config")
+        || lower.contains("configuration")
+        || lower.contains("setting")
+        || lower.contains("env")
+        || query.contains('=')
+        || query.contains(':') && !query.contains(char::is_whitespace)
+}
+
+fn controlled_expansions<'a>(terms: impl Iterator<Item = &'a str>) -> HashMap<Term, f64> {
+    let mut expansions = HashMap::new();
+
+    for term in terms {
+        for expansion in expansions_for(term) {
+            expansions.insert(Term(expansion.to_string()), 0.35);
+        }
+    }
+
+    expansions
+}
+
+fn expansions_for(term: &str) -> &'static [&'static str] {
+    match term {
+        "db" => &["database"],
+        "auth" => &["authentication", "authorization"],
+        "cfg" | "config" => &["configuration"],
+        "repo" => &["repository"],
+        "err" => &["error"],
+        "msg" => &["message"],
+        "req" => &["request"],
+        "res" => &["response", "result"],
+        _ => &[],
+    }
 }
 
 impl std::fmt::Display for AnalyzedQuery {
@@ -104,5 +314,92 @@ impl std::fmt::Display for AnalyzedQuery {
         terms.sort_unstable();
 
         write!(f, "{}", terms.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+    use rust_stemmers::{Algorithm, Stemmer};
+
+    use super::{AnalyzedQuery, QueryExpansionConfig, QueryIntent, classify_query_intent};
+    use crate::{config::Config, index::Term};
+
+    fn test_config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: Stemmer::create(Algorithm::English),
+            stop_words: stop_words::get(stop_words::LANGUAGE::English)
+                .par_iter()
+                .map(|word| word.to_string())
+                .collect::<HashSet<String>>(),
+        }
+    }
+
+    #[test]
+    fn classifies_query_intents() {
+        assert_eq!(
+            classify_query_intent("src/ranking/bm25.rs"),
+            QueryIntent::Path
+        );
+        assert_eq!(
+            classify_query_intent("BM25HyperParams"),
+            QueryIntent::Identifier
+        );
+        assert_eq!(
+            classify_query_intent("failed to deserialize evaluation JSON data"),
+            QueryIntent::ErrorMessage
+        );
+        assert_eq!(
+            classify_query_intent("cargo.toml dependencies"),
+            QueryIntent::Config
+        );
+        assert_eq!(
+            classify_query_intent("how bm25 scoring works"),
+            QueryIntent::NaturalLanguage
+        );
+    }
+
+    #[test]
+    fn controlled_expansion_is_downweighted_and_gated_by_intent() {
+        let config = test_config();
+        let expanded = AnalyzedQuery::new_code_search_with_expansion(
+            "auth config",
+            &config,
+            QueryExpansionConfig {
+                controlled: true,
+                feedback: false,
+            },
+        );
+        let auth_weight = expanded
+            .terms()
+            .find(|(term, _)| **term == Term("auth".to_string()))
+            .unwrap()
+            .1
+            .weight;
+        let authentication_weight = expanded
+            .terms()
+            .find(|(term, _)| **term == Term("authentication".to_string()))
+            .unwrap()
+            .1
+            .weight;
+
+        assert!(authentication_weight < auth_weight);
+
+        let path_query = AnalyzedQuery::new_code_search_with_expansion(
+            "src/auth.rs",
+            &config,
+            QueryExpansionConfig {
+                controlled: true,
+                feedback: false,
+            },
+        );
+        assert!(
+            path_query
+                .terms()
+                .all(|(term, _)| term.0 != "authentication")
+        );
     }
 }

--- a/crates/core/src/ranking/bm25f.rs
+++ b/crates/core/src/ranking/bm25f.rs
@@ -6,7 +6,7 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use crate::{
     error::RankingError,
     index::{DocId, DocumentField, InvertedIndex, Term, TermDocument},
-    query::{AnalyzedQuery, QueryTerm},
+    query::{AnalyzedQuery, QueryIntent, QueryTerm},
     ranking::{scorer::Scorer, utils::idf},
 };
 
@@ -37,6 +37,58 @@ impl BM25FHyperParams {
     pub fn field_weight(&self, field: DocumentField) -> f64 {
         self.field_weights.get(&field).copied().unwrap_or(1.0)
     }
+
+    pub fn intent_field_weight(&self, field: DocumentField, intent: QueryIntent) -> f64 {
+        let base = self.field_weight(field);
+        let multiplier = match intent {
+            QueryIntent::Path => match field {
+                DocumentField::FileName => 1.5,
+                DocumentField::RelativePath => 2.2,
+                DocumentField::Extension => 1.4,
+                DocumentField::Content => 0.45,
+                DocumentField::Identifier
+                | DocumentField::Comment
+                | DocumentField::StringLiteral => 0.6,
+            },
+            QueryIntent::Identifier => match field {
+                DocumentField::FileName => 1.15,
+                DocumentField::RelativePath => 1.1,
+                DocumentField::Identifier => 1.7,
+                DocumentField::Content => 0.75,
+                DocumentField::Extension
+                | DocumentField::Comment
+                | DocumentField::StringLiteral => 0.8,
+            },
+            QueryIntent::ErrorMessage => match field {
+                DocumentField::StringLiteral => 2.0,
+                DocumentField::Content => 1.25,
+                DocumentField::Comment => 0.9,
+                DocumentField::FileName
+                | DocumentField::RelativePath
+                | DocumentField::Extension
+                | DocumentField::Identifier => 0.7,
+            },
+            QueryIntent::Config => match field {
+                DocumentField::FileName => 1.5,
+                DocumentField::RelativePath => 1.8,
+                DocumentField::Extension => 1.7,
+                DocumentField::Identifier => 1.25,
+                DocumentField::Content => 0.9,
+                DocumentField::Comment | DocumentField::StringLiteral => 0.8,
+            },
+            QueryIntent::NaturalLanguage => match field {
+                DocumentField::Content => 1.1,
+                DocumentField::Comment => 1.35,
+                DocumentField::Identifier => 0.9,
+                DocumentField::FileName
+                | DocumentField::RelativePath
+                | DocumentField::Extension
+                | DocumentField::StringLiteral => 0.8,
+            },
+        };
+
+        base * multiplier
+    }
 }
 
 pub fn get_configuration() -> Result<BM25FHyperParams, RankingError> {
@@ -52,6 +104,7 @@ impl BM25F {
         &self,
         inverted_index: &InvertedIndex,
         term_doc: &TermDocument,
+        intent: QueryIntent,
     ) -> f64 {
         if term_doc.field_frequencies.is_empty() {
             return term_doc.term_freq as f64;
@@ -74,7 +127,7 @@ impl BM25F {
                 let normalized_tf = tf
                     / (1.0 - self.hyper_params.b
                         + self.hyper_params.b * field_length / avg_field_length);
-                self.hyper_params.field_weight(field) * normalized_tf
+                self.hyper_params.intent_field_weight(field, intent) * normalized_tf
             })
             .sum()
     }
@@ -93,7 +146,7 @@ impl Scorer for BM25F {
     fn score(
         &self,
         inverted_index: &InvertedIndex,
-        _: &AnalyzedQuery,
+        query: &AnalyzedQuery,
         _: &Term,
         query_term: QueryTerm,
         documents: &HashMap<DocId, TermDocument>,
@@ -103,7 +156,8 @@ impl Scorer for BM25F {
         let idf = idf(num_docs, documents.len());
 
         documents.par_iter().for_each(|(doc_id, term_doc)| {
-            let weighted_tf = self.weighted_term_frequency(inverted_index, term_doc);
+            let weighted_tf =
+                self.weighted_term_frequency(inverted_index, term_doc, query.intent());
             let score = self.score_weighted_tf(query_term.weight, idf, weighted_tf);
 
             *scores.entry(*doc_id).or_insert(0.0) += score;
@@ -199,7 +253,7 @@ mod tests {
         let weighted_tf = BM25F {
             hyper_params: BM25FHyperParams::code_search_defaults(),
         }
-        .weighted_term_frequency(&index, term_doc);
+        .weighted_term_frequency(&index, term_doc, crate::query::QueryIntent::Identifier);
 
         assert!(weighted_tf > term_doc.term_freq as f64);
     }

--- a/crates/core/src/ranking/explanation.rs
+++ b/crates/core/src/ranking/explanation.rs
@@ -1,4 +1,4 @@
-use crate::index::DocumentField;
+use crate::{index::DocumentField, query::QueryIntent};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScoredWithExplanations {
@@ -14,17 +14,27 @@ pub struct ScoreWithExplanation {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScoreExplanation {
     pub final_score: f64,
+    pub query_intent: QueryIntent,
     pub terms: Vec<TermExplanation>,
+    pub static_quality: Vec<StaticQualityContribution>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TermExplanation {
     pub term: String,
+    pub provenance: String,
     pub query_weight: f64,
     pub term_frequency: usize,
     pub document_frequency: usize,
     pub idf: f64,
     pub matched_fields: Vec<FieldContribution>,
+    pub contribution: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StaticQualityContribution {
+    pub signal: String,
+    pub value: f64,
     pub contribution: f64,
 }
 

--- a/crates/core/src/ranking/features.rs
+++ b/crates/core/src/ranking/features.rs
@@ -169,7 +169,10 @@ fn _term_key(term: &Term) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, path::PathBuf};
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    };
 
     use super::{export_feature_rows, export_pairwise_preferences};
     use crate::{
@@ -212,10 +215,7 @@ mod tests {
         );
 
         assert_eq!(rows.len(), 3);
-        assert!(
-            rows.iter()
-                .any(|row| row.preferred_doc == PathBuf::from("a.rs")
-                    && row.dispreferred_doc == PathBuf::from("b.rs"))
-        );
+        assert!(rows.iter().any(|row| row.preferred_doc == Path::new("a.rs")
+            && row.dispreferred_doc == Path::new("b.rs")));
     }
 }

--- a/crates/core/src/ranking/features.rs
+++ b/crates/core/src/ranking/features.rs
@@ -1,12 +1,17 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    io::{BufRead, Write},
+    path::PathBuf,
+};
 
 use crate::{
+    evaluation::dataset::{EvaluationData, Relevance},
     index::{DocumentField, InvertedIndex, Term},
     query::{AnalyzedQuery, QueryTermProvenance},
     ranking::{RankingAlgo, Score},
 };
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct RankingFeatureRow {
     pub query_id: String,
     pub query: String,
@@ -18,13 +23,141 @@ pub struct RankingFeatureRow {
     pub expansion_provenance: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct PairwisePreferenceRow {
     pub query_id: String,
     pub preferred_doc: PathBuf,
     pub dispreferred_doc: PathBuf,
     pub preferred_relevance: usize,
     pub dispreferred_relevance: usize,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FeatureExportRecord {
+    Feature(RankingFeatureRow),
+    PairwisePreference(PairwisePreferenceRow),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FeatureIoError {
+    #[error("feature export I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("feature record JSON failed: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+pub trait FeatureRecordSink {
+    type Error;
+
+    fn write_record(&mut self, record: &FeatureExportRecord) -> Result<(), Self::Error>;
+}
+
+pub trait FeatureRecordSource {
+    type Error;
+
+    fn read_records(&mut self) -> Result<Vec<FeatureExportRecord>, Self::Error>;
+}
+
+pub struct JsonlFeatureSink<W> {
+    writer: W,
+}
+
+impl<W> JsonlFeatureSink<W>
+where
+    W: Write,
+{
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W> FeatureRecordSink for JsonlFeatureSink<W>
+where
+    W: Write,
+{
+    type Error = FeatureIoError;
+
+    fn write_record(&mut self, record: &FeatureExportRecord) -> Result<(), Self::Error> {
+        serde_json::to_writer(&mut self.writer, record)?;
+        self.writer.write_all(b"\n")?;
+        Ok(())
+    }
+}
+
+pub struct JsonlFeatureSource<R> {
+    reader: R,
+}
+
+impl<R> JsonlFeatureSource<R>
+where
+    R: BufRead,
+{
+    pub fn new(reader: R) -> Self {
+        Self { reader }
+    }
+}
+
+impl<R> FeatureRecordSource for JsonlFeatureSource<R>
+where
+    R: BufRead,
+{
+    type Error = FeatureIoError;
+
+    fn read_records(&mut self) -> Result<Vec<FeatureExportRecord>, Self::Error> {
+        self.reader
+            .by_ref()
+            .lines()
+            .filter_map(|line| match line {
+                Ok(line) if line.trim().is_empty() => None,
+                other => Some(other),
+            })
+            .map(|line| {
+                let line = line?;
+                serde_json::from_str(&line).map_err(FeatureIoError::from)
+            })
+            .collect()
+    }
+}
+
+pub fn export_evaluation_features_to_sink<S>(
+    sink: &mut S,
+    index: &InvertedIndex,
+    ranking_algorithm: &RankingAlgo,
+    evaluation_data: &EvaluationData,
+    top_n: usize,
+) -> Result<(), S::Error>
+where
+    S: FeatureRecordSink,
+{
+    for (query_index, example) in evaluation_data.examples.iter().enumerate() {
+        let query_id = format!("q{}", query_index + 1);
+        let relevance = example
+            .results
+            .iter()
+            .filter_map(|result| match &result.relevance {
+                Relevance::Relevant(rank) => Some((result.path.clone(), *rank)),
+                Relevance::NonRelevant => None,
+            })
+            .collect::<BTreeMap<PathBuf, usize>>();
+
+        for row in export_feature_rows(
+            index,
+            ranking_algorithm,
+            &query_id,
+            &example.query,
+            top_n,
+            &relevance,
+        ) {
+            sink.write_record(&FeatureExportRecord::Feature(row))?;
+        }
+
+        for row in export_pairwise_preferences(&query_id, &relevance) {
+            sink.write_record(&FeatureExportRecord::PairwisePreference(row))?;
+        }
+    }
+
+    Ok(())
 }
 
 pub fn export_feature_rows(
@@ -174,7 +307,10 @@ mod tests {
         path::{Path, PathBuf},
     };
 
-    use super::{export_feature_rows, export_pairwise_preferences};
+    use super::{
+        FeatureExportRecord, FeatureRecordSink, FeatureRecordSource, JsonlFeatureSink,
+        JsonlFeatureSource, export_feature_rows, export_pairwise_preferences,
+    };
     use crate::{
         index::InvertedIndex,
         query::AnalyzedQuery,
@@ -217,5 +353,31 @@ mod tests {
         assert_eq!(rows.len(), 3);
         assert!(rows.iter().any(|row| row.preferred_doc == Path::new("a.rs")
             && row.dispreferred_doc == Path::new("b.rs")));
+    }
+
+    #[test]
+    fn jsonl_sink_and_source_round_trip_feature_records() {
+        let mut bytes = Vec::new();
+        let record = FeatureExportRecord::PairwisePreference(super::PairwisePreferenceRow {
+            query_id: "q1".to_string(),
+            preferred_doc: PathBuf::from("a.rs"),
+            dispreferred_doc: PathBuf::from("b.rs"),
+            preferred_relevance: 1,
+            dispreferred_relevance: 2,
+        });
+
+        JsonlFeatureSink::new(&mut bytes)
+            .write_record(&record)
+            .unwrap();
+        let mut source = JsonlFeatureSource::new(std::io::Cursor::new(bytes));
+
+        let records = source.read_records().unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert!(matches!(
+            &records[0],
+            FeatureExportRecord::PairwisePreference(row)
+                if row.preferred_doc == Path::new("a.rs")
+        ));
     }
 }

--- a/crates/core/src/ranking/features.rs
+++ b/crates/core/src/ranking/features.rs
@@ -1,0 +1,221 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use crate::{
+    index::{DocumentField, InvertedIndex, Term},
+    query::{AnalyzedQuery, QueryTermProvenance},
+    ranking::{RankingAlgo, Score},
+};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RankingFeatureRow {
+    pub query_id: String,
+    pub query: String,
+    pub query_intent: String,
+    pub doc_path: PathBuf,
+    pub rank: usize,
+    pub relevance: Option<usize>,
+    pub features: BTreeMap<String, f64>,
+    pub expansion_provenance: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PairwisePreferenceRow {
+    pub query_id: String,
+    pub preferred_doc: PathBuf,
+    pub dispreferred_doc: PathBuf,
+    pub preferred_relevance: usize,
+    pub dispreferred_relevance: usize,
+}
+
+pub fn export_feature_rows(
+    index: &InvertedIndex,
+    ranking_algorithm: &RankingAlgo,
+    query_id: &str,
+    query: &AnalyzedQuery,
+    top_n: usize,
+    relevance: &BTreeMap<PathBuf, usize>,
+) -> Vec<RankingFeatureRow> {
+    let ranked = ranking_algorithm
+        .rank(index, query, top_n)
+        .map(|scores| scores.0)
+        .unwrap_or_default();
+
+    ranked
+        .iter()
+        .enumerate()
+        .map(|(rank, score)| RankingFeatureRow {
+            query_id: query_id.to_string(),
+            query: query.original_text().to_string(),
+            query_intent: format!("{:?}", query.intent()),
+            doc_path: score.doc_path.clone(),
+            rank: rank + 1,
+            relevance: relevance.get(&score.doc_path).copied(),
+            features: features_for_score(index, query, score),
+            expansion_provenance: expansion_provenance(query),
+        })
+        .collect()
+}
+
+pub fn export_pairwise_preferences(
+    query_id: &str,
+    relevance: &BTreeMap<PathBuf, usize>,
+) -> Vec<PairwisePreferenceRow> {
+    let judged = relevance.iter().collect::<Vec<_>>();
+    let mut rows = Vec::new();
+
+    for (preferred_doc, preferred_rank) in &judged {
+        for (dispreferred_doc, dispreferred_rank) in &judged {
+            if preferred_rank < dispreferred_rank {
+                rows.push(PairwisePreferenceRow {
+                    query_id: query_id.to_string(),
+                    preferred_doc: (*preferred_doc).clone(),
+                    dispreferred_doc: (*dispreferred_doc).clone(),
+                    preferred_relevance: **preferred_rank,
+                    dispreferred_relevance: **dispreferred_rank,
+                });
+            }
+        }
+    }
+
+    rows
+}
+
+fn features_for_score(
+    index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    score: &Score,
+) -> BTreeMap<String, f64> {
+    let mut features = BTreeMap::from([("ranking_score".to_string(), score.score)]);
+    let Some(doc_id) = index.doc_id(&score.doc_path) else {
+        return features;
+    };
+    let Some(metadata) = index.document(doc_id) else {
+        return features;
+    };
+
+    for (name, value) in metadata.quality_signals.features() {
+        features.insert(format!("static.{name}"), value);
+    }
+
+    for field in DocumentField::ALL {
+        let count = query
+            .terms()
+            .filter_map(|(term, _)| {
+                index
+                    .get_postings(term)
+                    .and_then(|docs| docs.get(&doc_id))
+                    .map(|term_doc| term_doc.field_term_freq(field))
+            })
+            .sum::<usize>();
+        features.insert(format!("field_match.{}", field.as_str()), count as f64);
+    }
+
+    features.insert(
+        "path_exact_contains_query".to_string(),
+        contains_normalized(&score.doc_path.to_string_lossy(), query.original_text()),
+    );
+    features.insert(
+        "filename_exact_contains_query".to_string(),
+        score
+            .doc_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map_or(0.0, |file_name| {
+                contains_normalized(file_name, query.original_text())
+            }),
+    );
+    features.insert(
+        "expansion.controlled_terms".to_string(),
+        provenance_count(query, QueryTermProvenance::ControlledExpansion) as f64,
+    );
+    features.insert(
+        "expansion.feedback_terms".to_string(),
+        provenance_count(query, QueryTermProvenance::Feedback) as f64,
+    );
+    features.insert("regex.literal_evidence".to_string(), 0.0);
+
+    features
+}
+
+fn contains_normalized(haystack: &str, needle: &str) -> f64 {
+    let haystack = haystack.to_ascii_lowercase();
+    let needle = needle.trim().to_ascii_lowercase();
+    if !needle.is_empty() && haystack.contains(&needle) {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+fn provenance_count(query: &AnalyzedQuery, provenance: QueryTermProvenance) -> usize {
+    query
+        .terms()
+        .filter(|(_, query_term)| query_term.provenance == provenance)
+        .count()
+}
+
+fn expansion_provenance(query: &AnalyzedQuery) -> BTreeMap<String, String> {
+    query
+        .terms()
+        .filter(|(_, query_term)| query_term.provenance != QueryTermProvenance::Original)
+        .map(|(term, query_term)| (term.0.clone(), query_term.provenance.as_str().to_string()))
+        .collect()
+}
+
+#[allow(dead_code)]
+fn _term_key(term: &Term) -> &str {
+    &term.0
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    use super::{export_feature_rows, export_pairwise_preferences};
+    use crate::{
+        index::InvertedIndex,
+        query::AnalyzedQuery,
+        ranking::{BM25HyperParams, RankingAlgo},
+    };
+
+    #[test]
+    fn exports_inspectable_feature_rows() {
+        let index = InvertedIndex::from_documents(&[("src/lib.rs", &[("rust", 2)])]);
+        let query = AnalyzedQuery::from_frequencies(
+            "rust",
+            [(crate::index::Term("rust".to_string()), 1)].into(),
+        );
+
+        let rows = export_feature_rows(
+            &index,
+            &RankingAlgo::BM25(BM25HyperParams { k1: 1.2, b: 0.75 }),
+            "q1",
+            &query,
+            1,
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(rows[0].query_id, "q1");
+        assert!(rows[0].features.contains_key("ranking_score"));
+        assert!(rows[0].features.contains_key("static.file_depth"));
+    }
+
+    #[test]
+    fn exports_pairwise_preferences_from_graded_judgments() {
+        let rows = export_pairwise_preferences(
+            "q1",
+            &BTreeMap::from([
+                (PathBuf::from("a.rs"), 1),
+                (PathBuf::from("b.rs"), 3),
+                (PathBuf::from("c.rs"), 2),
+            ]),
+        );
+
+        assert_eq!(rows.len(), 3);
+        assert!(
+            rows.iter()
+                .any(|row| row.preferred_doc == PathBuf::from("a.rs")
+                    && row.dispreferred_doc == PathBuf::from("b.rs"))
+        );
+    }
+}

--- a/crates/core/src/ranking/feedback.rs
+++ b/crates/core/src/ranking/feedback.rs
@@ -1,0 +1,207 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    index::{DocId, DocumentField, InvertedIndex, Term},
+    query::AnalyzedQuery,
+    ranking::Score,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FeedbackTerm {
+    pub term: Term,
+    pub weight: f64,
+    pub source_documents: Vec<DocId>,
+    pub source_fields: Vec<DocumentField>,
+}
+
+pub fn expand_query_with_feedback(
+    index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    seed_results: &[Score],
+    max_terms: usize,
+) -> AnalyzedQuery {
+    let mut feedback_terms = collect_feedback_terms(index, query, seed_results, max_terms);
+    feedback_terms.sort_by(|left, right| {
+        right
+            .weight
+            .total_cmp(&left.weight)
+            .then_with(|| left.term.0.cmp(&right.term.0))
+    });
+    feedback_terms.truncate(max_terms);
+
+    let mut expanded = query.clone();
+    expanded.add_feedback_terms(
+        feedback_terms
+            .into_iter()
+            .map(|term| (term.term, term.weight))
+            .collect(),
+    );
+    expanded
+}
+
+pub fn collect_feedback_terms(
+    index: &InvertedIndex,
+    query: &AnalyzedQuery,
+    seed_results: &[Score],
+    max_terms: usize,
+) -> Vec<FeedbackTerm> {
+    let original_terms = query
+        .terms()
+        .map(|(term, _)| term.0.clone())
+        .collect::<HashSet<_>>();
+    let seed_doc_ids = seed_results
+        .iter()
+        .filter_map(|score| index.doc_id(&score.doc_path))
+        .collect::<Vec<_>>();
+    let mut candidates: HashMap<Term, FeedbackAccumulator> = HashMap::new();
+
+    for (term, documents) in index.postings_iter() {
+        if original_terms.contains(&term.0) {
+            continue;
+        }
+
+        for doc_id in &seed_doc_ids {
+            let Some(term_doc) = documents.get(doc_id) else {
+                continue;
+            };
+            let field_weight = high_signal_field_weight(term_doc);
+            if field_weight == 0.0 {
+                continue;
+            }
+
+            let accumulator = candidates.entry(term.clone()).or_default();
+            accumulator.weight += field_weight * term_doc.term_freq as f64;
+            accumulator.source_documents.insert(*doc_id);
+            for field in DocumentField::ALL {
+                if term_doc.field_term_freq(field) > 0 && high_signal_field(field) > 0.0 {
+                    accumulator.source_fields.insert(field);
+                }
+            }
+        }
+    }
+
+    let mut terms = candidates
+        .into_iter()
+        .map(|(term, accumulator)| {
+            let mut source_documents = accumulator.source_documents.into_iter().collect::<Vec<_>>();
+            source_documents.sort_by_key(|doc_id| doc_id.as_u32());
+            let mut source_fields = accumulator.source_fields.into_iter().collect::<Vec<_>>();
+            source_fields.sort_unstable();
+
+            FeedbackTerm {
+                term,
+                weight: (accumulator.weight / seed_doc_ids.len().max(1) as f64).min(0.45),
+                source_documents,
+                source_fields,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    terms.sort_by(|left, right| {
+        right
+            .weight
+            .total_cmp(&left.weight)
+            .then_with(|| left.term.0.cmp(&right.term.0))
+    });
+    terms.truncate(max_terms);
+    terms
+}
+
+#[derive(Default)]
+struct FeedbackAccumulator {
+    weight: f64,
+    source_documents: HashSet<DocId>,
+    source_fields: HashSet<DocumentField>,
+}
+
+fn high_signal_field_weight(term_doc: &crate::index::TermDocument) -> f64 {
+    DocumentField::ALL
+        .into_iter()
+        .map(|field| high_signal_field(field) * term_doc.field_term_freq(field) as f64)
+        .sum()
+}
+
+fn high_signal_field(field: DocumentField) -> f64 {
+    match field {
+        DocumentField::FileName => 0.28,
+        DocumentField::RelativePath => 0.20,
+        DocumentField::Identifier => 0.22,
+        DocumentField::StringLiteral => 0.12,
+        DocumentField::Extension | DocumentField::Content | DocumentField::Comment => 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        path::{Path, PathBuf},
+    };
+
+    use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+    use rust_stemmers::{Algorithm, Stemmer};
+
+    use super::{collect_feedback_terms, expand_query_with_feedback};
+    use crate::{
+        config::Config,
+        index::InvertedIndex,
+        query::{AnalyzedQuery, QueryTermProvenance},
+        ranking::Score,
+    };
+
+    fn test_config() -> Config {
+        Config {
+            n_grams: 1,
+            stemmer: Stemmer::create(Algorithm::English),
+            stop_words: stop_words::get(stop_words::LANGUAGE::English)
+                .par_iter()
+                .map(|word| word.to_string())
+                .collect::<HashSet<String>>(),
+        }
+    }
+
+    fn write_temp_file(dir: &Path, name: &str, content: &str) {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn feedback_terms_use_high_signal_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "src/auth_repository.rs", "fn unrelated() {}");
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let seed_results = vec![Score {
+            doc_path: PathBuf::from("src/auth_repository.rs"),
+            score: 1.0,
+        }];
+        let query = AnalyzedQuery::new_code_search("auth", &test_config());
+
+        let terms = collect_feedback_terms(&index, &query, &seed_results, 4);
+
+        assert!(terms.iter().any(|term| term.term.0 == "repository"));
+    }
+
+    #[test]
+    fn expanded_query_marks_feedback_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "src/auth_repository.rs", "fn unrelated() {}");
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let seed_results = vec![Score {
+            doc_path: PathBuf::from("src/auth_repository.rs"),
+            score: 1.0,
+        }];
+        let query = AnalyzedQuery::new_code_search("auth", &test_config());
+
+        let expanded = expand_query_with_feedback(&index, &query, &seed_results, 4);
+
+        assert!(
+            expanded
+                .terms()
+                .any(|(term, query_term)| term.0 == "repository"
+                    && query_term.provenance == QueryTermProvenance::Feedback)
+        );
+    }
+}

--- a/crates/core/src/ranking/mod.rs
+++ b/crates/core/src/ranking/mod.rs
@@ -2,6 +2,8 @@ pub mod bm25;
 pub mod bm25f;
 pub mod cosine_similarity;
 pub mod explanation;
+pub mod features;
+pub mod feedback;
 pub mod scorer;
 pub mod tf_idf;
 mod utils;
@@ -11,7 +13,7 @@ pub use bm25f::{BM25F, BM25FHyperParams};
 pub use cosine_similarity::CosineSimilarity;
 pub use explanation::{
     FieldContribution, ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations,
-    TermExplanation,
+    StaticQualityContribution, TermExplanation,
 };
 pub use scorer::{RankingAlgo, RankingAlgorithm, Score, Scored, Scorer};
 pub use tf_idf::TFIDF;

--- a/crates/core/src/ranking/scorer.rs
+++ b/crates/core/src/ranking/scorer.rs
@@ -8,8 +8,8 @@ use crate::{
     query::{AnalyzedQuery, QueryTerm},
     ranking::{
         BM25, BM25F, BM25FHyperParams, BM25HyperParams, CosineSimilarity, FieldContribution,
-        ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations, TFIDF, TermExplanation,
-        get_configuration, idf,
+        ScoreExplanation, ScoreWithExplanation, ScoredWithExplanations, StaticQualityContribution,
+        TFIDF, TermExplanation, get_configuration, idf,
     },
 };
 
@@ -126,7 +126,13 @@ impl RankingAlgo {
 
         let mut ranking = self.score(inverted_index, query).0;
 
-        ranking.sort_by(|a, b| b.score.total_cmp(&a.score));
+        apply_static_quality_priors(inverted_index, &mut ranking);
+
+        ranking.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.doc_path.cmp(&b.doc_path))
+        });
         ranking.truncate(top_n);
 
         if ranking.is_empty() {
@@ -158,6 +164,25 @@ impl RankingAlgo {
         Some(ScoredWithExplanations { results })
     }
 
+    pub fn rank_with_feedback(
+        &self,
+        inverted_index: &InvertedIndex,
+        query: &AnalyzedQuery,
+        top_n: usize,
+        feedback_docs: usize,
+        feedback_terms: usize,
+    ) -> Option<Scored> {
+        let seed = self.rank(inverted_index, query, feedback_docs)?;
+        let expanded = crate::ranking::feedback::expand_query_with_feedback(
+            inverted_index,
+            query,
+            &seed.0,
+            feedback_terms,
+        );
+
+        self.rank(inverted_index, &expanded, top_n)
+    }
+
     fn explain_doc(
         &self,
         inverted_index: &InvertedIndex,
@@ -177,7 +202,12 @@ impl RankingAlgo {
             }
         };
 
-        ScoreExplanation { final_score, terms }
+        ScoreExplanation {
+            final_score,
+            query_intent: query.intent(),
+            terms,
+            static_quality: static_quality_explanation(inverted_index, doc_id),
+        }
     }
 
     pub fn needs_fielded_index(&self) -> bool {
@@ -213,6 +243,7 @@ fn explain_bm25(
 
             Some(TermExplanation {
                 term: term.0.clone(),
+                provenance: query_term.provenance.as_str().to_string(),
                 query_weight: query_term.weight,
                 term_frequency: term_doc.term_freq,
                 document_frequency: documents.len(),
@@ -236,6 +267,7 @@ fn explain_matched_terms(
             let term_doc = documents.get(&doc_id)?;
             Some(TermExplanation {
                 term: term.0.clone(),
+                provenance: query_term.provenance.as_str().to_string(),
                 query_weight: query_term.weight,
                 term_frequency: term_doc.term_freq,
                 document_frequency: documents.len(),
@@ -264,11 +296,13 @@ fn explain_bm25f(
             let documents = inverted_index.get_postings(term)?;
             let term_doc = documents.get(&doc_id)?;
             let term_idf = idf(num_docs, documents.len());
-            let weighted_tf = scorer.weighted_term_frequency(inverted_index, term_doc);
+            let weighted_tf =
+                scorer.weighted_term_frequency(inverted_index, term_doc, query.intent());
             let contribution = scorer.score_weighted_tf(query_term.weight, term_idf, weighted_tf);
 
             Some(TermExplanation {
                 term: term.0.clone(),
+                provenance: query_term.provenance.as_str().to_string(),
                 query_weight: query_term.weight,
                 term_frequency: term_doc.term_freq,
                 document_frequency: documents.len(),
@@ -276,7 +310,8 @@ fn explain_bm25f(
                 matched_fields: field_contributions_with_weights(
                     term_doc,
                     contribution,
-                    &hyper_params.field_weights,
+                    hyper_params,
+                    query.intent(),
                 ),
                 contribution,
             })
@@ -285,13 +320,39 @@ fn explain_bm25f(
 }
 
 fn field_contributions(term_doc: &TermDocument, contribution: f64) -> Vec<FieldContribution> {
-    field_contributions_with_weights(term_doc, contribution, &HashMap::new())
+    let mut fields = DocumentField::ALL
+        .into_iter()
+        .filter_map(|field| {
+            let term_frequency = term_doc.field_term_freq(field);
+            if term_frequency == 0 {
+                return None;
+            }
+
+            let proportional_contribution = if term_doc.term_freq == 0 {
+                0.0
+            } else {
+                contribution * term_frequency as f64 / term_doc.term_freq as f64
+            };
+
+            Some(FieldContribution {
+                field,
+                term_frequency,
+                field_length: term_doc.field_length(field),
+                field_weight: 1.0,
+                contribution: proportional_contribution,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    fields.sort_by_key(|field| field.field);
+    fields
 }
 
 fn field_contributions_with_weights(
     term_doc: &TermDocument,
     contribution: f64,
-    field_weights: &HashMap<DocumentField, f64>,
+    hyper_params: &BM25FHyperParams,
+    intent: crate::query::QueryIntent,
 ) -> Vec<FieldContribution> {
     let mut fields = DocumentField::ALL
         .into_iter()
@@ -311,7 +372,7 @@ fn field_contributions_with_weights(
                 field,
                 term_frequency,
                 field_length: term_doc.field_length(field),
-                field_weight: field_weights.get(&field).copied().unwrap_or(1.0),
+                field_weight: hyper_params.intent_field_weight(field, intent),
                 contribution: proportional_contribution,
             })
         })
@@ -319,6 +380,91 @@ fn field_contributions_with_weights(
 
     fields.sort_by_key(|field| field.field);
     fields
+}
+
+fn apply_static_quality_priors(inverted_index: &InvertedIndex, ranking: &mut [Score]) {
+    for score in ranking {
+        if let Some(doc_id) = inverted_index.doc_id(&score.doc_path)
+            && let Some(metadata) = inverted_index.document(doc_id)
+        {
+            score.score += metadata.quality_signals.prior_score();
+        }
+    }
+}
+
+fn static_quality_explanation(
+    inverted_index: &InvertedIndex,
+    doc_id: DocId,
+) -> Vec<StaticQualityContribution> {
+    let Some(metadata) = inverted_index.document(doc_id) else {
+        return Vec::new();
+    };
+    let signals = &metadata.quality_signals;
+
+    let mut contributions = Vec::new();
+    push_quality(&mut contributions, "generated", signals.generated, -0.55);
+    push_quality(&mut contributions, "vendor", signals.vendor, -0.45);
+    push_quality(&mut contributions, "test", signals.test, -0.08);
+    push_quality(&mut contributions, "entry_point", signals.entry_point, 0.28);
+    push_quality(&mut contributions, "readme", signals.readme, 0.22);
+    push_quality(
+        &mut contributions,
+        "config_or_manifest",
+        signals.config_or_manifest,
+        0.20,
+    );
+    push_quality(
+        &mut contributions,
+        "public_entry_point",
+        signals.public_entry_point,
+        0.12,
+    );
+
+    let depth_contribution = match signals.file_depth {
+        0 | 1 => 0.10,
+        2 => 0.04,
+        3..=5 => 0.0,
+        _ => -0.08,
+    };
+    contributions.push(StaticQualityContribution {
+        signal: "file_depth".to_string(),
+        value: signals.file_depth as f64,
+        contribution: depth_contribution,
+    });
+
+    let size_contribution = if signals.file_size_bytes > 750_000 {
+        -0.18
+    } else if signals.file_size_bytes > 250_000 {
+        -0.08
+    } else {
+        0.0
+    };
+    contributions.push(StaticQualityContribution {
+        signal: "file_size_bytes".to_string(),
+        value: signals.file_size_bytes as f64,
+        contribution: size_contribution,
+    });
+
+    contributions.push(StaticQualityContribution {
+        signal: "reference_count".to_string(),
+        value: signals.reference_count as f64,
+        contribution: signals.reference_count.min(12) as f64 * 0.015,
+    });
+
+    contributions
+}
+
+fn push_quality(
+    contributions: &mut Vec<StaticQualityContribution>,
+    signal: &str,
+    value: bool,
+    contribution: f64,
+) {
+    contributions.push(StaticQualityContribution {
+        signal: signal.to_string(),
+        value: if value { 1.0 } else { 0.0 },
+        contribution: if value { contribution } else { 0.0 },
+    });
 }
 
 impl FromStr for RankingAlgo {
@@ -350,7 +496,7 @@ mod tests {
     use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
     use rust_stemmers::{Algorithm, Stemmer};
 
-    use super::{BM25HyperParams, RankingAlgo};
+    use super::{BM25FHyperParams, BM25HyperParams, RankingAlgo};
     use crate::{
         config::Config,
         index::{DocumentField, InvertedIndex, Term},
@@ -467,5 +613,52 @@ mod tests {
                 .any(|field| field.field == DocumentField::RelativePath)
         );
         assert_eq!(result.explanation.final_score, result.score.score);
+    }
+
+    #[test]
+    fn static_quality_prior_can_penalize_generated_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(dir.path(), "src/lib.rs", "needle");
+        write_temp_file(
+            dir.path(),
+            "vendor/generated/client.rs",
+            "// generated\nneedle needle",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let query = AnalyzedQuery::new_code_search("needle", &test_config());
+
+        let ranked = RankingAlgo::BM25F(BM25FHyperParams::code_search_defaults())
+            .rank(&index, &query, 2)
+            .unwrap()
+            .0;
+
+        assert_eq!(ranked[0].doc_path, PathBuf::from("src/lib.rs"));
+    }
+
+    #[test]
+    fn explanations_include_static_quality_and_intent() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_file(
+            dir.path(),
+            "src/main.rs",
+            "fn main() { println!(\"needle\"); }",
+        );
+
+        let index = InvertedIndex::new_fielded(dir.path(), &test_config(), Some(dir.path()));
+        let query = AnalyzedQuery::new_code_search("needle", &test_config());
+
+        let explanations = RankingAlgo::BM25F(BM25FHyperParams::code_search_defaults())
+            .rank_with_explanations(&index, &query, 1)
+            .unwrap();
+        let explanation = &explanations.results[0].explanation;
+
+        assert_eq!(explanation.query_intent, query.intent());
+        assert!(
+            explanation
+                .static_quality
+                .iter()
+                .any(|signal| signal.signal == "entry_point" && signal.contribution > 0.0)
+        );
     }
 }


### PR DESCRIPTION
- add static document quality signals for generated/vendor/test files, entry points, manifests, shallow paths, and reference-like metadata
- classify `query` intent so path, identifier, error-message, config, and natural-language queries can use different `bm25f` field weights
- add controlled weighted expansion for common code abbreviations with provenance in ranking explanations while keeping expansion disabled by default
- add optional pseudo-relevance feedback behind `--feedback-expansion` with bounded high-signal field mining and per-query eval visibility
- export query-document ranking features and pairwise preference rows through eval JSONL without adding training to the search hot path