### PR TITLE
feat(search): respect gitignore during indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +616,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -987,6 +1026,7 @@ dependencies = [
  "config",
  "criterion",
  "dashmap",
+ "ignore",
  "memmap2",
  "rayon",
  "regex",
@@ -1004,7 +1044,6 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "url",
- "walkdir",
 ]
 
 [[package]]

--- a/crates/cli/src/live_search.rs
+++ b/crates/cli/src/live_search.rs
@@ -16,7 +16,7 @@ use notify::{
 use repo_reaper_core::{
     config::Config as ReaperConfig,
     index::{
-        InvertedIndex, SearchEngine,
+        FileSystemIndexCorpus, InvertedIndex, SearchEngine,
         event_log::{IndexEvent, append_event, clear_events, read_events, replay_events},
         inverted_file::InvertedFileLayout,
         snapshot::{load_snapshot, write_snapshot},
@@ -32,6 +32,7 @@ pub(crate) struct LiveSearchOptions {
     pub(crate) feedback_expansion: bool,
     pub(crate) index_dir: Option<PathBuf>,
     pub(crate) reindex: bool,
+    pub(crate) respect_gitignore: bool,
 }
 
 pub(crate) fn run(
@@ -56,11 +57,23 @@ pub(crate) fn run(
             }
             Err(error) => {
                 eprintln!("rebuilding index because snapshot could not be loaded: {error}");
-                build_index(&directory, &config, transformer.as_ref(), fielded)
+                build_index(
+                    &directory,
+                    &config,
+                    transformer.as_ref(),
+                    fielded,
+                    options.respect_gitignore,
+                )
             }
         }
     } else {
-        build_index(&directory, &config, transformer.as_ref(), fielded)
+        build_index(
+            &directory,
+            &config,
+            transformer.as_ref(),
+            fielded,
+            options.respect_gitignore,
+        )
     };
 
     let engine = SearchEngine::new(index);
@@ -99,11 +112,15 @@ fn build_index(
     config: &ReaperConfig,
     transformer: &(impl Fn(&str) -> HashMap<repo_reaper_core::index::Term, u32> + Sync),
     fielded: bool,
+    respect_gitignore: bool,
 ) -> InvertedIndex {
+    let corpus = FileSystemIndexCorpus::new(directory, None::<&PathBuf>)
+        .with_respect_gitignore(respect_gitignore);
+
     if fielded {
-        InvertedIndex::new_fielded(directory, config, None)
+        InvertedIndex::from_corpus_fielded(&corpus, config).index
     } else {
-        InvertedIndex::new(directory, transformer, None)
+        InvertedIndex::from_corpus(&corpus, transformer).index
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -74,6 +74,9 @@ struct Args {
     /// Rebuild the ranked index even when a compatible snapshot exists
     #[clap(long, default_value = "false")]
     reindex: bool,
+    /// Respect Git ignore rules when indexing inside a Git repository
+    #[clap(long, default_value_t = true, action = clap::ArgAction::Set)]
+    respect_gitignore: bool,
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -91,7 +94,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     if let Some(Commands::Regex { pattern }) = &args.command {
-        run_regex_search(&args.directory, pattern)?;
+        run_regex_search(&args.directory, pattern, args.respect_gitignore)?;
         return Ok(());
     }
 
@@ -110,7 +113,7 @@ fn main() -> Result<()> {
     }
 
     if args.stats {
-        print_directory_stats(&args.directory, &config);
+        print_directory_stats(&args.directory, &config, args.respect_gitignore);
         return Ok(());
     }
 
@@ -124,17 +127,18 @@ fn main() -> Result<()> {
             feedback_expansion: args.feedback_expansion,
             index_dir: args.index_dir,
             reindex: args.reindex,
+            respect_gitignore: args.respect_gitignore,
         },
     )
 }
 
-fn print_directory_stats(directory: &Path, config: &ReaperConfig) {
+fn print_directory_stats(directory: &Path, config: &ReaperConfig, respect_gitignore: bool) {
     println!("Indexing files in {}", directory.display());
-    let index = InvertedIndex::new(
-        directory,
-        |content: &str| n_gram_transform(content, config),
-        None::<&Path>,
-    );
+    let corpus = repo_reaper_core::index::FileSystemIndexCorpus::new(directory, None::<&Path>)
+        .with_respect_gitignore(respect_gitignore);
+    let index =
+        InvertedIndex::from_corpus(&corpus, |content: &str| n_gram_transform(content, config))
+            .index;
     println!("Successfully indexed {} files", index.num_docs());
     print_corpus_stats(&index.corpus_stats(10));
 }
@@ -159,8 +163,10 @@ fn print_corpus_stats(stats: &CorpusStats) {
     }
 }
 
-fn run_regex_search(directory: &Path, pattern: &str) -> Result<()> {
-    let matches = RegexSearchEngine::new(directory).search(pattern)?;
+fn run_regex_search(directory: &Path, pattern: &str, respect_gitignore: bool) -> Result<()> {
+    let matches = RegexSearchEngine::new(directory)
+        .with_respect_gitignore(respect_gitignore)
+        .search(pattern)?;
 
     if matches.is_empty() {
         println!("No regex matches found");

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,7 +20,7 @@ tree-sitter = [
 workspace = true
 
 [dependencies]
-walkdir = "^2.5"
+ignore = "^0.4"
 rust-stemmers = "^1.2"
 stop-words = "^0.10"
 config = { version = "^0.15", default-features = false, features = ["yaml"] }

--- a/crates/core/src/fs_walk.rs
+++ b/crates/core/src/fs_walk.rs
@@ -1,0 +1,41 @@
+use std::path::{Path, PathBuf};
+
+use ignore::WalkBuilder;
+
+pub(crate) fn filesystem_files(
+    root: &Path,
+    respect_gitignore: bool,
+) -> Vec<Result<PathBuf, WalkError>> {
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .hidden(false)
+        .ignore(false)
+        .git_global(respect_gitignore)
+        .git_ignore(respect_gitignore)
+        .git_exclude(respect_gitignore)
+        .require_git(true);
+
+    builder
+        .build()
+        .filter_map(|entry| match entry {
+            Ok(entry)
+                if entry
+                    .file_type()
+                    .is_some_and(|file_type| file_type.is_file()) =>
+            {
+                Some(Ok(entry.path().to_path_buf()))
+            }
+            Ok(_) => None,
+            Err(error) => Some(Err(WalkError {
+                path: None,
+                message: error.to_string(),
+            })),
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WalkError {
+    pub(crate) path: Option<PathBuf>,
+    pub(crate) message: String,
+}

--- a/crates/core/src/index/corpus.rs
+++ b/crates/core/src/index/corpus.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use walkdir::WalkDir;
+use crate::fs_walk::filesystem_files;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexCorpusDocument {
@@ -53,6 +53,7 @@ pub trait IndexCorpus {
 pub struct FileSystemIndexCorpus {
     root: PathBuf,
     drop_prefix: Option<PathBuf>,
+    respect_gitignore: bool,
 }
 
 impl FileSystemIndexCorpus {
@@ -60,7 +61,13 @@ impl FileSystemIndexCorpus {
         Self {
             root: root.as_ref().to_path_buf(),
             drop_prefix: drop_prefix.map(|path| path.as_ref().to_path_buf()),
+            respect_gitignore: true,
         }
+    }
+
+    pub fn with_respect_gitignore(mut self, respect_gitignore: bool) -> Self {
+        self.respect_gitignore = respect_gitignore;
+        self
     }
 
     fn index_path(&self, full_path: &Path) -> PathBuf {
@@ -77,33 +84,28 @@ impl IndexCorpus for FileSystemIndexCorpus {
         let mut documents = Vec::new();
         let mut skipped_documents = Vec::new();
 
-        for entry in WalkDir::new(&self.root) {
-            let entry = match entry {
-                Ok(entry) => entry,
+        for path in filesystem_files(&self.root, self.respect_gitignore) {
+            let full_path = match path {
+                Ok(path) => path,
                 Err(error) => {
                     skipped_documents.push(SkippedDocument {
-                        path: error.path().map(Path::to_path_buf).unwrap_or_default(),
+                        path: error.path.unwrap_or_default(),
                         reason: IndexSkipReason::Walk {
-                            message: error.to_string(),
+                            message: error.message,
                         },
                     });
                     continue;
                 }
             };
 
-            if !entry.file_type().is_file() {
-                continue;
-            }
-
-            let full_path = entry.path();
-            match fs::read_to_string(full_path) {
+            match fs::read_to_string(&full_path) {
                 Ok(content) => documents.push(IndexCorpusDocument {
-                    path: self.index_path(full_path),
+                    path: self.index_path(&full_path),
                     file_size_bytes: content.len() as u64,
                     content,
                 }),
                 Err(error) => skipped_documents.push(SkippedDocument {
-                    path: full_path.to_path_buf(),
+                    path: full_path,
                     reason: IndexSkipReason::Read {
                         kind: error.kind(),
                         message: error.to_string(),
@@ -118,5 +120,84 @@ impl IndexCorpus for FileSystemIndexCorpus {
             documents,
             skipped_documents,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FileSystemIndexCorpus, IndexCorpus};
+
+    #[test]
+    fn scan_respects_gitignore_inside_git_repository_by_default() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join(".git")).unwrap();
+        std::fs::write(root.path().join(".gitignore"), "node_modules/\n").unwrap();
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        std::fs::create_dir(workspace.join("src")).unwrap();
+        std::fs::create_dir(workspace.join("node_modules")).unwrap();
+        std::fs::write(workspace.join("src/lib.rs"), "pub fn indexed() {}").unwrap();
+        std::fs::write(workspace.join("node_modules/dep.js"), "ignored").unwrap();
+
+        let scan = FileSystemIndexCorpus::new(&workspace, None::<&std::path::Path>).scan();
+        let paths = scan
+            .documents
+            .into_iter()
+            .map(|document| document.path)
+            .collect::<Vec<_>>();
+
+        assert_eq!(paths, vec![workspace.join("src/lib.rs")]);
+    }
+
+    #[test]
+    fn scan_can_opt_out_of_gitignore_filtering() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join(".git")).unwrap();
+        std::fs::write(root.path().join(".gitignore"), "node_modules/\n").unwrap();
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        std::fs::create_dir(workspace.join("src")).unwrap();
+        std::fs::create_dir(workspace.join("node_modules")).unwrap();
+        std::fs::write(workspace.join("src/lib.rs"), "pub fn indexed() {}").unwrap();
+        std::fs::write(workspace.join("node_modules/dep.js"), "indexed").unwrap();
+
+        let scan = FileSystemIndexCorpus::new(&workspace, None::<&std::path::Path>)
+            .with_respect_gitignore(false)
+            .scan();
+        let paths = scan
+            .documents
+            .into_iter()
+            .map(|document| document.path)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                workspace.join("node_modules/dep.js"),
+                workspace.join("src/lib.rs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn scan_ignores_gitignore_without_git_repository() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(".gitignore"), "ignored.txt\n").unwrap();
+        std::fs::write(root.path().join("ignored.txt"), "indexed").unwrap();
+
+        let scan = FileSystemIndexCorpus::new(root.path(), None::<&std::path::Path>).scan();
+        let paths = scan
+            .documents
+            .into_iter()
+            .map(|document| document.path)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                root.path().join(".gitignore"),
+                root.path().join("ignored.txt")
+            ]
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod code_intelligence;
 pub mod config;
 pub mod error;
 pub mod evaluation;
+mod fs_walk;
 pub mod index;
 pub mod query;
 pub mod ranking;

--- a/crates/core/src/regex_search/corpus.rs
+++ b/crates/core/src/regex_search/corpus.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use walkdir::WalkDir;
+use crate::fs_walk::filesystem_files;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CorpusDocument {
@@ -19,21 +19,28 @@ pub trait RegexCorpus {
 #[derive(Debug, Clone)]
 pub struct FileSystemCorpus {
     root: PathBuf,
+    respect_gitignore: bool,
 }
 
 impl FileSystemCorpus {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            respect_gitignore: true,
+        }
+    }
+
+    pub fn with_respect_gitignore(mut self, respect_gitignore: bool) -> Self {
+        self.respect_gitignore = respect_gitignore;
+        self
     }
 }
 
 impl RegexCorpus for FileSystemCorpus {
     fn documents(&self) -> Vec<CorpusDocument> {
-        let mut paths = WalkDir::new(&self.root)
+        let mut paths = filesystem_files(&self.root, self.respect_gitignore)
             .into_iter()
             .filter_map(Result::ok)
-            .filter(|entry| entry.file_type().is_file())
-            .map(|entry| entry.path().to_path_buf())
             .collect::<Vec<_>>();
 
         paths.sort();
@@ -48,5 +55,59 @@ impl RegexCorpus for FileSystemCorpus {
 
     fn read_document(&self, path: &Path) -> Option<String> {
         fs::read_to_string(path).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FileSystemCorpus, RegexCorpus};
+
+    #[test]
+    fn documents_respect_gitignore_inside_git_repository_by_default() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join(".git")).unwrap();
+        std::fs::write(root.path().join(".gitignore"), "node_modules/\n").unwrap();
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        std::fs::create_dir(workspace.join("src")).unwrap();
+        std::fs::create_dir(workspace.join("node_modules")).unwrap();
+        std::fs::write(workspace.join("src/lib.rs"), "pub fn indexed() {}").unwrap();
+        std::fs::write(workspace.join("node_modules/dep.js"), "ignored").unwrap();
+
+        let paths = FileSystemCorpus::new(&workspace)
+            .documents()
+            .into_iter()
+            .map(|document| document.path)
+            .collect::<Vec<_>>();
+
+        assert_eq!(paths, vec![workspace.join("src/lib.rs")]);
+    }
+
+    #[test]
+    fn documents_can_opt_out_of_gitignore_filtering() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join(".git")).unwrap();
+        std::fs::write(root.path().join(".gitignore"), "node_modules/\n").unwrap();
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        std::fs::create_dir(workspace.join("src")).unwrap();
+        std::fs::create_dir(workspace.join("node_modules")).unwrap();
+        std::fs::write(workspace.join("src/lib.rs"), "pub fn indexed() {}").unwrap();
+        std::fs::write(workspace.join("node_modules/dep.js"), "indexed").unwrap();
+
+        let paths = FileSystemCorpus::new(&workspace)
+            .with_respect_gitignore(false)
+            .documents()
+            .into_iter()
+            .map(|document| document.path)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                workspace.join("node_modules/dep.js"),
+                workspace.join("src/lib.rs"),
+            ]
+        );
     }
 }

--- a/crates/core/src/regex_search/engine.rs
+++ b/crates/core/src/regex_search/engine.rs
@@ -4,18 +4,27 @@ use std::{
 };
 
 use regex::Regex;
-use walkdir::WalkDir;
 
 use super::{RegexSearchError, RegexSearchMatch, line_range_for_match};
+use crate::fs_walk::filesystem_files;
 
 #[derive(Debug, Clone)]
 pub struct RegexSearchEngine {
     root: PathBuf,
+    respect_gitignore: bool,
 }
 
 impl RegexSearchEngine {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            respect_gitignore: true,
+        }
+    }
+
+    pub fn with_respect_gitignore(mut self, respect_gitignore: bool) -> Self {
+        self.respect_gitignore = respect_gitignore;
+        self
     }
 
     pub fn search(&self, pattern: &str) -> Result<Vec<RegexSearchMatch>, RegexSearchError> {
@@ -34,11 +43,9 @@ impl RegexSearchEngine {
     }
 
     fn candidate_files(&self) -> Vec<PathBuf> {
-        let mut files = WalkDir::new(&self.root)
+        let mut files = filesystem_files(&self.root, self.respect_gitignore)
             .into_iter()
             .filter_map(Result::ok)
-            .filter(|entry| entry.file_type().is_file())
-            .map(|entry| entry.path().to_path_buf())
             .collect::<Vec<_>>();
 
         files.sort();


### PR DESCRIPTION
- add a shared filesystem walker that uses the `ignore` crate to honor `.gitignore`, `.git/info/exclude`, and global git ignore rules only when the indexed root is inside a git repo
- default ranked and regex filesystem corpora to respecting git ignore rules while preserving an explicit `with_respect_gitignore(false)` opt-out for dependency searches
- expose `--respect-gitignore <true|false>` through the cli so users can opt back into indexing ignored deps when needed
- cover parent-git-repo behavior, opt-out behavior, and non-git directories with focused corpus tests